### PR TITLE
feat: use quarters as labels instead of dates

### DIFF
--- a/components/roadmap-grid/grid-header.tsx
+++ b/components/roadmap-grid/grid-header.tsx
@@ -1,11 +1,16 @@
 import { dayjs } from '../../lib/client/dayjs';
+
 import styles from './Roadmap.module.css';
 
 export function GridHeader({ ticks, index }) {
+  const date = dayjs(ticks).utc();
+  const quarterNum = date.quarter();
+  const year = date.year().toString().slice(2);
+
   return (
     <>
       <div key={index} className={`${styles.item} ${styles.itemHeader}`}>
-        <span>{`${dayjs(ticks).utc().format('MMM DD, YYYY')}`}</span>
+        <span>{`Q${quarterNum} '${year}`}</span>
       </div>
     </>
   );

--- a/lib/client/dayjs.ts
+++ b/lib/client/dayjs.ts
@@ -4,11 +4,13 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import minMax from 'dayjs/plugin/minMax';
 import utc from 'dayjs/plugin/utc';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear'
 
 dayjs.extend(customParseFormat);
 dayjs.extend(utc);
 dayjs.extend(minMax);
 dayjs.extend(localizedFormat);
 dayjs.extend(advancedFormat);
+dayjs.extend(quarterOfYear);
 
 export { dayjs };


### PR DESCRIPTION
- chore: add dayjs quarterofyear plugin
- feat: use Quarter identifier for labels
