### PR TITLE
fix(click): Preventing navigation on items with no-children

### DIFF
--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -24,10 +24,10 @@ export function GridRow({
 
   const urlParams = paramsFromUrl(milestone.html_url)
   const childLink = `/roadmap/github.com/${urlParams.owner}/${urlParams.repo}/issues/${urlParams.issue_number}`
+  const clickable = milestone.children.length > 0;
 
-  return (
-    <NextLink key={index} href={childLink} passHref>
-      <div
+  const rowItem = (
+    <div
         style={{
           gridColumnStart: `span ${span}`,
           gridColumnEnd: `${closest === span ? closest + 1 : closest}`,
@@ -35,11 +35,20 @@ export function GridRow({
             milestone.completion_rate.toString(2),
           )}%, white 0%, white ${100 - parseInt(milestone.completion_rate.toString(2))}%)`,
         }}
-        className={`${styles.item} ${styles.issueItem} ${styles.wrapperLink}`}
+        className={`${styles.item} ${styles.issueItem} ${clickable && styles.wrapperLink}`}
       >
         <div className={styles.milestoneTitleWrapper}>{milestone.title}</div>
         <div className={styles.milestoneDate}>{milestone.due_date}</div>
       </div>
-    </NextLink>
   );
+
+  if (clickable) {
+    return (
+      <NextLink key={index} href={childLink} passHref>
+        {rowItem}
+      </NextLink>
+    );
+  }
+
+  return rowItem;
 }


### PR DESCRIPTION
Closes: #62 

This is a temp fix till we have a better UX around milestones with no children.