### PR TITLE
fix (quarter-labels): Should not be duplicated

### DIFF
--- a/components/roadmap-grid/grid-header.tsx
+++ b/components/roadmap-grid/grid-header.tsx
@@ -5,7 +5,7 @@ import styles from './Roadmap.module.css';
 export function GridHeader({ ticks, index }) {
   const date = dayjs(ticks).utc();
   const quarterNum = date.quarter();
-  const year = date.year().toString().slice(2);
+  const year = date.format('YY');
 
   return (
     <>

--- a/components/roadmap/RoadmapHeader.tsx
+++ b/components/roadmap/RoadmapHeader.tsx
@@ -1,9 +1,7 @@
-import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 
-import { Box, Link, Progress, Text } from '@chakra-ui/react';
+import { Link, Text } from '@chakra-ui/react';
 
-import { getLinkForRoadmapChild } from '../../lib/client/linkUtils';
 import { IssueData } from '../../lib/types';
 
 interface RoadmapHeaderProps {

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,9 +1,8 @@
 const BASE_PROTOCOL = (!!process.env.IS_LOCAL && 'http') || 'https';
 const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL;
-const API_URL = new URL(`${BASE_PROTOCOL}://${BASE_URL}/api/roadmap`);
+export const API_URL = new URL(`${BASE_PROTOCOL}://${BASE_URL}/api/roadmap`);
 
-const TEN_DAYS_IN_SECONDS = 864000;
-const OFFSET_MIN_MONTHS = 2;
-const OFFSET_MAX_MONTHS = 3;
-
-export { API_URL, TEN_DAYS_IN_SECONDS, OFFSET_MIN_MONTHS, OFFSET_MAX_MONTHS };
+export const TEN_DAYS_IN_SECONDS = 864000;
+export const OFFSET_MIN_MONTHS = 2;
+export const OFFSET_MAX_MONTHS = 3;
+export const DEFAULT_TICK_COUNT = 5;

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,8 +1,15 @@
 const BASE_PROTOCOL = (!!process.env.IS_LOCAL && 'http') || 'https';
 const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL;
-export const API_URL = new URL(`${BASE_PROTOCOL}://${BASE_URL}/api/roadmap`);
+const API_URL = new URL(`${BASE_PROTOCOL}://${BASE_URL}/api/roadmap`);
+const DEFAULT_TICK_COUNT = 5;
+const OFFSET_MAX_MONTHS = 3;
+const OFFSET_MIN_MONTHS = 2;
+const TEN_DAYS_IN_SECONDS = 864000;
 
-export const TEN_DAYS_IN_SECONDS = 864000;
-export const OFFSET_MIN_MONTHS = 2;
-export const OFFSET_MAX_MONTHS = 3;
-export const DEFAULT_TICK_COUNT = 5;
+export {
+  API_URL,
+  DEFAULT_TICK_COUNT,
+  OFFSET_MAX_MONTHS,
+  OFFSET_MIN_MONTHS,
+  TEN_DAYS_IN_SECONDS
+}

--- a/lib/client/getTicks.ts
+++ b/lib/client/getTicks.ts
@@ -1,13 +1,24 @@
 import { utcTicks } from 'd3';
 import dayjs from 'dayjs';
-
+import { DEFAULT_TICK_COUNT } from '../../config/constants';
 import { getQuantiles } from './getQuantiles';
 
 const getTicks = (dates: Date[], totalTicks) => {
   const count = totalTicks;
-  const min = dayjs.min(dates.map((v) => dayjs.utc(v))).toDate();
-  const max = dayjs.max(dates.map((v) => dayjs.utc(v))).toDate();
-  const ticks = utcTicks(min, max, count);
+  const utcDates = dates.map((date) => dayjs(date).utc());
+  let min = dayjs.min(utcDates);
+  let max = dayjs.max(utcDates);
+  let incrementMax = false;
+  while (max.diff(min, 'months') < (3 * DEFAULT_TICK_COUNT)) {
+    if (incrementMax) {
+      max = max.add(1, 'quarter');
+    } else {
+      min = min.subtract(1, 'quarter');
+    }
+    incrementMax = !incrementMax;
+  }
+
+  const ticks = utcTicks(min.toDate(), max.toDate(), count);
   const quantiles = getQuantiles(ticks, totalTicks);
 
   return quantiles;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,7 +1,4 @@
-import dayjs from 'dayjs';
-import quarterOfYear from 'dayjs/plugin/quarterOfYear';
-
-dayjs.extend(quarterOfYear);
+import { dayjs } from './client/dayjs';
 
 /**
  * Date parser based on: https://github.com/pln-planning-tools/Starmaps/blob/main/User%20Guide.md#eta


### PR DESCRIPTION
Closes: #92 

@SgtPooki I am not even sure if this is what you had in mind, but in this PR:
- I am calculating the diff between `max` and `min`
- Adding and subtracting quarter till the required threshold is reached.
- Skewed milestones get roughly aligned in the centre.

Feel free to close this if this is not something that would work.