### PR TITLE
fix: Fixing Tick Alignment Calculations

### DIFF
--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -93,7 +93,7 @@ export function RoadmapDetailed({ issueData }: { issueData: IssueData; }) {
                 <GroupItem issueData={issueData} group={group} />
                 {!!group.items &&
                   _.sortBy(group.items, ['title']).map((item, index) => {
-                    return <GridRow key={index} milestone={item} index={index} timelineTicks={ticks} />;
+                    return <GridRow key={index} milestone={item} index={index} timelineTicks={ticksHeader} />;
                   })}
               </GroupWrapper>
             );

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -19,7 +19,7 @@ export function GridRow({
   timelineTicks: Date[];
 }) {
   const closestDateIdx = getClosest({
-    currentDate: dayjs.utc(milestone.due_date).toDate(),
+    currentDate: dayjs.utc(milestone.due_date).endOf('quarter').toDate(),
     dates: timelineTicks,
     totalTimelineTicks: timelineTicks.length,
   });

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -18,12 +18,13 @@ export function GridRow({
   index: number;
   timelineTicks: Date[];
 }) {
-  const closest = getClosest({
+  const closestDateIdx = getClosest({
     currentDate: dayjs.utc(milestone.due_date).toDate(),
     dates: timelineTicks,
     totalTimelineTicks: timelineTicks.length,
   });
-  const span = 5;
+  const span = 4;
+  const closest = span * (closestDateIdx - 1);
 
   const childLink = getInternalLinkForIssue(milestone);
   const clickable = milestone.children.length > 0;
@@ -33,7 +34,7 @@ export function GridRow({
       key={index}
       style={{
         gridColumnStart: `span ${span}`,
-        gridColumnEnd: `${closest === span ? closest + 1 : closest}`,
+        gridColumnEnd: `${closest === span ? closest : closest - 1}`,
         background: `linear-gradient(90deg, rgba(166, 178, 255, 0.4) ${parseInt(
           milestone.completion_rate.toString(2),
         )}%, white 0%, white ${100 - parseInt(milestone.completion_rate.toString(2))}%)`,


### PR DESCRIPTION
Closes: #100 

In this PR:
- Recalculating ticks with headers as the source of truth, the intuition behind that is this alignment of header with the grid:
<img width="1488" alt="Screenshot 2022-11-16 at 6 32 07 PM" src="https://user-images.githubusercontent.com/1895906/202331957-17ae3b22-fdec-4af3-81ac-890fcdbb9a2f.png">

Demo: https://starmaps-git-fix-tick-alignment-ipfs-ignite.vercel.app/roadmap/github.com/filecoin-project/bacalhau/issues/1151