### PR TITLE
feat: significantly polish github url entry

### DIFF
--- a/components/RoadmapForm.tsx
+++ b/components/RoadmapForm.tsx
@@ -26,9 +26,10 @@ export function RoadmapForm() {
   const currentIssueUrl = useCurrentIssueUrl();
   const [issueUrl, setIssueUrl] = useState<string | null>();
   const [error, setError] = useState<Error | null>(null);
+  const [isInputBlanked, setIsInputBlanked] = useState<boolean>(false);
 
   useEffect(() => {
-    if (isEmpty(currentIssueUrl) && window.location.pathname.length > 1) {
+    if (!isInputBlanked && isEmpty(currentIssueUrl) && window.location.pathname.length > 1) {
       try {
         const urlObj = getValidUrlFromInput(window.location.pathname.replace('/roadmap', ''));
         setCurrentIssueUrl(urlObj.toString());
@@ -75,6 +76,10 @@ export function RoadmapForm() {
   if (isLoading) {
     inputRightElement = <Spinner />
   }
+  const onChangeHandler = (e) => {
+    setIsInputBlanked(true);
+    setCurrentIssueUrl(e.target.value ?? '')
+  };
   return (
     <form onSubmit={formSubmit}>
       <FormControl isInvalid={error != null}>
@@ -91,7 +96,7 @@ export function RoadmapForm() {
             aria-label='Issue URL'
             name='issue-url'
             autoComplete='url'
-            onChange={(e) => setCurrentIssueUrl(e.target.value)}
+            onChange={onChangeHandler}
             placeholder='https://github.com/...'
             bg={theme.light.header.input.background.color}
             borderColor={theme.light.header.input.border.color}

--- a/components/RoadmapForm.tsx
+++ b/components/RoadmapForm.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
-import { Box, Input, InputGroup, InputLeftElement, InputRightElement, Spinner, Text } from '@chakra-ui/react';
-import { ArrowForwardIcon, SearchIcon } from '@chakra-ui/icons'
+import { Button, FormControl, FormErrorMessage, Input, InputGroup, InputLeftElement, InputRightElement, Spinner, Text } from '@chakra-ui/react';
+import { SearchIcon } from '@chakra-ui/icons'
 import { match } from 'path-to-regexp';
 import { useEffect, useState } from 'react';
 
@@ -9,6 +9,8 @@ import styles from './RoadmapForm.module.css'
 import theme from './theme/constants'
 import { setCurrentIssueUrl, useCurrentIssueUrl } from '../hooks/useCurrentIssueUrl';
 import { isEmpty } from 'lodash';
+import { paramsFromUrl } from '../lib/paramsFromUrl';
+import { getValidUrlFromInput } from '../lib/getValidUrlFromInput';
 
 const slugsFromUrl: any = (url) => {
   const matchResult = match('/:owner/:repo/issues/:issue_number(\\d+)', {
@@ -23,63 +25,66 @@ export function RoadmapForm() {
   const isLoading = useIsLoading();
   const currentIssueUrl = useCurrentIssueUrl();
   const [issueUrl, setIssueUrl] = useState<string | null>();
-  const [error, setError] = useState();
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (isEmpty(currentIssueUrl)) {
-      const urlMatchParams = slugsFromUrl(window.location.pathname.replace('/roadmap/github.com', ''))?.params
-      if (urlMatchParams != null) {
-        const { owner, repo, issue_number } = urlMatchParams;
-        setCurrentIssueUrl(`https://github.com/${owner}/${repo}/issues/${issue_number}`);
-      }
-
+    if (isEmpty(currentIssueUrl) && window.location.pathname.length > 1) {
+      try {
+        const urlObj = getValidUrlFromInput(window.location.pathname.replace('/roadmap', ''));
+        setCurrentIssueUrl(urlObj.toString());
+      } catch {}
     }
-  }, [currentIssueUrl, slugsFromUrl])
+  }, [currentIssueUrl, getValidUrlFromInput, setCurrentIssueUrl])
 
   useEffect(() => {
     if (router.isReady) {
       if (!issueUrl) return;
-      const { owner, repo, issue_number } = slugsFromUrl(new URL(issueUrl).pathname).params;
-      setIssueUrl(null);
-      router.push(`/roadmap/github.com/${owner}/${repo}/issues/${issue_number}`).then(() => setIsLoading(false));
+      try {
+        const { owner, repo, issue_number } = paramsFromUrl(issueUrl);
+        setIssueUrl(null);
+        router.push(`/roadmap/github.com/${owner}/${repo}/issues/${issue_number}`).then(() => setIsLoading(false));
+      } catch (err){
+        setError(err as Error);
+        setIsLoading(false);
+      }
     }
   }, [router, issueUrl, setCurrentIssueUrl]);
 
   const formSubmit = (e) => {
     e.preventDefault();
     setIsLoading(true);
+    setError(null);
 
     try {
       if (currentIssueUrl == null) {
         throw new Error('currentIssueUrl is null');
       }
-      const newUrl = new URL(currentIssueUrl);
+      const newUrl = getValidUrlFromInput(currentIssueUrl);
       setIssueUrl(newUrl.toString());
-    } catch (err: any) {
-      setError(err);
+    } catch (err) {
+      setError(err as Error);
       setIsLoading(false);
     }
   }
 
   let inputRightElement = (
-    <Box className={styles.formSubmitButton} border="1px solid #8D8D8D" borderRadius="4px"  bg="rgba(141, 141, 141, 0.3)" onClick={formSubmit}>
+    <Button type="submit" isLoading={isLoading} className={styles.formSubmitButton} border="1px solid #8D8D8D" borderRadius="4px"  bg="rgba(141, 141, 141, 0.3)" onClick={formSubmit}>
       <Text p="6px 10px" color="white">⏎</Text>
-    </Box>
+    </Button>
   )
   if (isLoading) {
     inputRightElement = <Spinner />
   }
   return (
-    <>
-      <form
-        onSubmit={formSubmit}
-      >
+    <form onSubmit={formSubmit}>
+      <FormControl isInvalid={error != null}>
         <InputGroup>
           <InputLeftElement
             pointerEvents='none'
             children={<SearchIcon color='#FFFFFF' />}
           />
           <Input
+            type="text"
             value={currentIssueUrl}
             className={styles.urlInput}
             color={theme.light.header.input.text.color}
@@ -94,7 +99,8 @@ export function RoadmapForm() {
           />
           <InputRightElement cursor="pointer" children={inputRightElement}/>
         </InputGroup>
-      </form>
-    </>
+        <FormErrorMessage>{error?.message}</FormErrorMessage>
+      </FormControl>
+    </form>
   );
 }

--- a/components/RoadmapForm.tsx
+++ b/components/RoadmapForm.tsx
@@ -43,6 +43,15 @@ export function RoadmapForm() {
       try {
         const { owner, repo, issue_number } = paramsFromUrl(issueUrl);
         setIssueUrl(null);
+        if (window.location.pathname.includes(`github.com/${owner}/${repo}/issues/${issue_number}`)) {
+          setTimeout(() => {
+            /**
+             * Clear the error after a few seconds.
+             */
+            setError(null);
+          }, 5000);
+          throw new Error('Already viewing this issue');
+        }
         router.push(`/roadmap/github.com/${owner}/${repo}/issues/${issue_number}`).then(() => setIsLoading(false));
       } catch (err){
         setError(err as Error);

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { getTicks } from '../../lib/client/getTicks';
 import { DetailedViewGroup, IssueData } from '../../lib/types';
-import { addOffset, formatDateArrayDayJs, getInternalLinkForIssue } from '../../utils/general';
+import { addOffset, formatDateArrayDayJs, getInternalLinkForIssue } from '../../lib/general';
 import styles from './Roadmap.module.css';
 import { Grid } from './grid';
 import { GridHeader } from './grid-header';

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -4,7 +4,7 @@ import { Flex, Spacer, Text } from '@chakra-ui/react';
 import { dayjs } from '../../lib/client/dayjs';
 import { getClosest } from '../../lib/client/getClosest';
 import { IssueData } from '../../lib/types';
-import { getInternalLinkForIssue } from '../../utils/general';
+import { getInternalLinkForIssue } from '../../lib/general';
 import styles from './Roadmap.module.css';
 import { SvgGitHubLogoWithTooltip } from '../icons/svgr/SvgGitHubLogoWithTooltip';
 import getDateAsQuarter from '../../lib/client/getDateAsQuarter';

--- a/lib/backend/issue.ts
+++ b/lib/backend/issue.ts
@@ -1,6 +1,6 @@
 import { octokit } from './octokit';
 
-const getIssue = async ({ platform, owner, repo, issue_number }) => {
+const getIssue = async ({ owner, repo, issue_number }) => {
   try {
     const { data } = await octokit.rest.issues.get({
       mediaType: {

--- a/lib/client/dateUtils.ts
+++ b/lib/client/dateUtils.ts
@@ -1,6 +1,6 @@
 import { closestIndexTo } from 'date-fns';
 
-import { formatDateDayJs } from '../../utils/general';
+import { formatDateDayJs } from '../general';
 
 const getClosest = (dueDate: number | string | Date, dates: number[] | Date[]): number => {
   const closest = closestIndexTo(formatDateDayJs(dueDate as any), dates);

--- a/lib/client/linkUtils.ts
+++ b/lib/client/linkUtils.ts
@@ -1,4 +1,4 @@
-import { slugsFromUrl } from '../../utils/general';
+import { slugsFromUrl } from '../general';
 import { IssueData } from '../types';
 
 function getLinkForRoadmapChild(issueData: IssueData): string {

--- a/lib/client/linkUtils.ts
+++ b/lib/client/linkUtils.ts
@@ -1,13 +1,11 @@
-import { slugsFromUrl } from '../general';
+import { paramsFromUrl } from '../paramsFromUrl';
 import { IssueData } from '../types';
 
 function getLinkForRoadmapChild(issueData: IssueData): string {
-  const urlM = slugsFromUrl(new URL(issueData.html_url).pathname) as {
-    params: { owner: string; repo: string; issue_number: string };
-  };
+  const urlM = paramsFromUrl(issueData.html_url)
   // const { id, type } = roadmapChild;
   // const link = `${window.location.origin}/roadmap/${type}/${id}`;
-  return `/roadmap/github.com/${urlM.params.owner}/${urlM.params.repo}/issues/${urlM.params.issue_number}`;
+  return `/roadmap/github.com/${urlM.owner}/${urlM.repo}/issues/${urlM.issue_number}`;
 }
 
 export { getLinkForRoadmapChild };

--- a/lib/general.ts
+++ b/lib/general.ts
@@ -1,18 +1,12 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
-import { match } from 'path-to-regexp';
 
 import { dayjs } from './client/dayjs';
+import { paramsFromUrl } from './paramsFromUrl';
 import { IssueData } from './types';
 
 export const toTimestamp = (date) => (_.isDate(date) && +new Date(date)) || +new Date(date?.split('-'));
 
-export const slugsFromUrl: any = (url: string) => {
-  const matchResult = match('/:owner/:repo/issues/:issue_number(\\d+)', {
-    decode: decodeURIComponent,
-  })(url);
-  return matchResult;
-};
 
 export const formatDate = (date) => {
   if (_.isDate(date)) {
@@ -30,14 +24,6 @@ export const addOffset = (dates: Date[], { offsetStart, offsetEnd }: { offsetSta
   const datesWithOffset = dates.concat([offsetMin, offsetMax]);
 
   return datesWithOffset;
-};
-
-export const paramsFromUrl = (url: string) => {
-  try {
-    return { ...slugsFromUrl(new URL(url).pathname).params };
-  } catch (err) {
-    console.error('paramsFromUrl error:', err);
-  }
 };
 
 export const getInternalLinkForIssue = (issue?: IssueData): string => {

--- a/lib/general.ts
+++ b/lib/general.ts
@@ -2,8 +2,8 @@ import * as d3 from 'd3';
 import _ from 'lodash';
 import { match } from 'path-to-regexp';
 
-import { dayjs } from '../lib/client/dayjs';
-import { IssueData } from '../lib/types';
+import { dayjs } from './client/dayjs';
+import { IssueData } from './types';
 
 export const toTimestamp = (date) => (_.isDate(date) && +new Date(date)) || +new Date(date?.split('-'));
 

--- a/lib/getValidUrlFromInput.ts
+++ b/lib/getValidUrlFromInput.ts
@@ -1,0 +1,22 @@
+export function getValidUrlFromInput(urlString: string): URL {
+  if (urlString.includes('#')) {
+    urlString = urlString.replace('#', '/issues/')
+  } else if (!urlString.includes('issues')) {
+    throw new Error('Unsupported URL string. URLs should be formatted like a github issue')
+  }
+  /**
+   * Cannot construct a URL from the given string.
+   */
+  if (urlString.includes('http')) {
+    try {
+      return new URL(urlString)
+    } catch {}
+  }
+  if (urlString.includes('github.com')) {
+    try {
+      return new URL(`https://${urlString}`)
+    } catch {}
+  }
+
+  return new URL(urlString, 'https://github.com')
+};

--- a/lib/paramsFromUrl.ts
+++ b/lib/paramsFromUrl.ts
@@ -1,0 +1,16 @@
+import { getValidUrlFromInput } from './getValidUrlFromInput';
+import { slugsFromUrl } from './slugsFromUrl';
+import { UrlMatchSlugs } from './types';
+
+export const paramsFromUrl = (urlString: string): UrlMatchSlugs => {
+
+  try {
+    const urlObj = getValidUrlFromInput(urlString)
+    const matchResult = slugsFromUrl(urlObj.pathname)
+    if (matchResult !== false && matchResult.params != null) {
+      return { ...matchResult.params };
+    }
+  } catch { }
+
+  throw new Error('Unsupported URL');
+};

--- a/lib/slugsFromUrl.ts
+++ b/lib/slugsFromUrl.ts
@@ -1,0 +1,11 @@
+import { match, MatchResult } from 'path-to-regexp';
+
+import { UrlMatchSlugs } from './types';
+
+export const slugsFromUrl = (url: string): MatchResult<UrlMatchSlugs> | false => {
+  const matchResult = match<UrlMatchSlugs>('/:owner/:repo/issues/:issue_number(\\d+)', {
+    decode: decodeURIComponent,
+  })(url);
+
+  return matchResult;
+};

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -104,4 +104,10 @@ export interface GroupItemProps {
   group: DetailedViewGroup;
 }
 
+export interface UrlMatchSlugs {
+  owner: string;
+  repo: string;
+  issue_number: string;
+};
+
 export { IssueData, IssueStates, ParserGetChildrenResponse };

--- a/pages/api/roadmap.ts
+++ b/pages/api/roadmap.ts
@@ -5,7 +5,7 @@ import _, { result } from 'lodash';
 import { getIssue } from '../../lib/backend/issue';
 import { getChildren, getConfig } from '../../lib/parser';
 import { IssueData, ParserGetChildrenResponse, RoadmapApiResponse, RoadmapApiResponseFailure, RoadmapApiResponseSuccess } from '../../lib/types';
-import { paramsFromUrl } from '../../utils/general';
+import { paramsFromUrl } from '../../lib/general';
 import { errorManager } from '../../lib/backend/errorManager';
 
 const resolveChildren = (children: any[]): Promise<IssueData[]> => {

--- a/pages/api/roadmap.ts
+++ b/pages/api/roadmap.ts
@@ -5,7 +5,7 @@ import _, { result } from 'lodash';
 import { getIssue } from '../../lib/backend/issue';
 import { getChildren, getConfig } from '../../lib/parser';
 import { IssueData, ParserGetChildrenResponse, RoadmapApiResponse, RoadmapApiResponseFailure, RoadmapApiResponseSuccess } from '../../lib/types';
-import { paramsFromUrl } from '../../lib/general';
+import { paramsFromUrl } from '../../lib/paramsFromUrl';
 import { errorManager } from '../../lib/backend/errorManager';
 
 const resolveChildren = (children: any[]): Promise<IssueData[]> => {
@@ -17,7 +17,7 @@ const resolveChildren = (children: any[]): Promise<IssueData[]> => {
     if (_.isArray(children) && children.length === 0) reject('empty array');
 
     children.forEach((current) => {
-      getIssue({ ...paramsFromUrl(current.html_url) }).then((issueData) => {
+      getIssue(paramsFromUrl(current.html_url)).then((issueData) => {
         resultArray.push({ ...issueData, group: current.group });
         count += 1;
         if (count === children.length) {

--- a/pages/api/roadmap.ts
+++ b/pages/api/roadmap.ts
@@ -104,7 +104,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return;
   }
   try {
-    const rootIssue = await getIssue({ platform, owner, repo, issue_number });
+    const rootIssue = await getIssue({ owner, repo, issue_number });
     if (rootIssue && !rootIssue?.labels?.includes('starmaps')) {
       errorManager.addError({
         issueUrl: rootIssue.html_url,

--- a/tests/unit/getValidUrlFromInput.test.ts
+++ b/tests/unit/getValidUrlFromInput.test.ts
@@ -1,0 +1,22 @@
+import { getValidUrlFromInput } from '../../lib/getValidUrlFromInput';
+
+const expectedUrlObj = new URL('https://github.com/pln-planning-tools/Starmaps/issues/1')
+describe('getValidUrlFromInput', function() {
+  [
+    'https://github.com/pln-planning-tools/Starmaps/issues/1',
+    'github.com/pln-planning-tools/Starmaps/issues/1',
+    'github.com/pln-planning-tools/Starmaps#1',
+    'pln-planning-tools/Starmaps/issues/1',
+    'pln-planning-tools/Starmaps#1',
+  ].forEach((urlString) => {
+    it(`should return a URL object for ${urlString}`, () => {
+      expect(getValidUrlFromInput(urlString)).toEqual(expectedUrlObj);
+    });
+  })
+
+  it('should throw an error on an invalid urlString', function() {
+    // expect(getValidUrlFromInput('invalid url string')).toEqual(new URL('https://www.google.com'));
+    expect(() => getValidUrlFromInput('invalid url string')).toThrowError('Unsupported URL string. URLs should be formatted like a github issue');
+    // console.log(`getValidUrlFromInput('invalid url string'): `, getValidUrlFromInput('invalid url string'));
+  })
+})

--- a/tests/unit/paramsFromUrl.test.ts
+++ b/tests/unit/paramsFromUrl.test.ts
@@ -1,0 +1,35 @@
+import { paramsFromUrl } from '../../lib/paramsFromUrl';
+
+describe('paramsFromUrl', function() {
+  it('should return UrlMatchSlugs for full github issue url', () => {
+    expect(paramsFromUrl('https://github.com/pln-planning-tools/Starmaps/issues/1')).toEqual({
+      owner: 'pln-planning-tools',
+      repo: 'Starmaps',
+      issue_number: '1',
+    });
+  });
+
+  it('should return UrlMatchSlugs for partial github issue url', () => {
+    expect(paramsFromUrl('github.com/pln-planning-tools/Starmaps/issues/1')).toEqual({
+      owner: 'pln-planning-tools',
+      repo: 'Starmaps',
+      issue_number: '1',
+    });
+  });
+
+  it('should return UrlMatchSlugs for an issue identifier path', () => {
+    expect(paramsFromUrl('pln-planning-tools/Starmaps/issues/1')).toEqual({
+      owner: 'pln-planning-tools',
+      repo: 'Starmaps',
+      issue_number: '1',
+    });
+  });
+
+  it('should return UrlMatchSlugs for a shorthand github issue identifier', () => {
+    expect(paramsFromUrl('pln-planning-tools/Starmaps#1')).toEqual({
+      owner: 'pln-planning-tools',
+      repo: 'Starmaps',
+      issue_number: '1',
+    });
+  });
+})

--- a/tests/unit/slugsFromUrl.test.ts
+++ b/tests/unit/slugsFromUrl.test.ts
@@ -1,0 +1,39 @@
+import { slugsFromUrl } from '../../lib/slugsFromUrl';
+
+describe('slugsFromUrl', () => {
+
+  const successCase = '/pln-planning-tools/Starmaps/issues/1'
+  it(`should return UrlMatchSlugs for "${successCase}"`, () => {
+    expect(slugsFromUrl(successCase)).toEqual({
+      index: 0,
+      params: {
+        owner: 'pln-planning-tools',
+        repo: 'Starmaps',
+        issue_number: '1',
+      },
+      path: successCase
+    });
+  });
+  [
+    'https://github.com/pln-planning-tools/Starmaps/issues/1',
+    'github.com/pln-planning-tools/Starmaps/issues/1',
+    'github.com/pln-planning-tools/Starmaps#1',
+    'pln-planning-tools/Starmaps/issues/1',
+    'pln-planning-tools/Starmaps#1',
+  ].forEach((urlString) => {
+    it(`should return false for "${urlString}"`, () => {
+      expect(slugsFromUrl(urlString)).toEqual(false);
+    });
+  })
+  // it('should return false for partial github issue url', () => {
+  //   expect(slugsFromUrl('github.com/pln-planning-tools/Starmaps/issues/1')).toEqual(false);
+  // });
+
+  // it('should return false for an issue identifier path', () => {
+  //   expect(slugsFromUrl('pln-planning-tools/Starmaps/issues/1')).toEqual(false);
+  // });
+
+  // it('should return false for a shorthand github issue identifier', () => {
+  //   expect(slugsFromUrl('pln-planning-tools/Starmaps#1')).toEqual(false);
+  // });
+});


### PR DESCRIPTION
- chore: move utils/general.ts -> lib/general.ts
- feat: support more github-esque url strings
  * `https://github.com/pln-planning-tools/Starmaps/issues/1`
  * `github.com/pln-planning-tools/Starmaps/issues/1`
  * `github.com/pln-planning-tools/Starmaps#1`
  * `pln-planning-tools/Starmaps/issues/1`
  * `pln-planning-tools/Starmaps#1`
- feat: much better url error handling
