### PR TITLE
docs: eta date must be in ISO format/with quarter

### DIFF
--- a/User Guide.md
+++ b/User Guide.md
@@ -59,7 +59,7 @@ eta: YYYY-MM-DD
 example: 2023-02-01
 ```
 - ETA must occur at the beginning of a new line
-- Date must be in ordered specified; we support ".", "-", and "/" as delimiters.
+- Date must be either in ISO 8601 or in the mentioned querterly format.
 - **Note:** If you are linking to an existing GitHub issue as a milestone, you must edit the issue to include both an ETA and the starmaps label. See the next section for more details on label requirements.
 
 #### Label Requirement


### PR DESCRIPTION
According to the parser implementation
https://github.com/pln-planning-tools/StarMaps/blob/0d41d94ca118efde9ea15948ecfb61e97e9db84a/lib/helpers.ts#L12 the date must be either in ISO 8601 format or specified with a quarter. This commit updates the user guide accordingly.