### PR TITLE
feat: fix css-grid milestone accuracy

### DIFF
--- a/components/inputs/NumSlider.tsx
+++ b/components/inputs/NumSlider.tsx
@@ -1,0 +1,23 @@
+import Slider from 'react-input-slider';
+
+import { setWeekTicks, useWeekTicks } from '../../hooks/useWeekTicks';
+
+interface NumSelectorProps {
+  value: number;
+  min: number;
+  max: number;
+  setValue: (value: number) => void;
+  msg?: string;
+}
+
+function NumSlider({value, min, max, setValue, msg}: NumSelectorProps) {
+  const message = msg ?? `Select a number: `;
+  return (
+    <>
+      <span>{message}</span>
+      <Slider axis='x' xmax={max} xmin={min} x={value} onChange={({ x }) => setValue(x)} />
+    </>
+  );
+}
+
+export default NumSlider;

--- a/components/inputs/NumSlider.tsx
+++ b/components/inputs/NumSlider.tsx
@@ -6,14 +6,16 @@ interface NumSelectorProps {
   max: number;
   setValue: (value: number) => void;
   msg?: string;
+  step?: number;
 }
 
-function NumSlider({value, min, max, setValue, msg}: NumSelectorProps) {
+function NumSlider({value, min, max, setValue, msg, step}: NumSelectorProps) {
   const message = msg ?? `Select a number: `;
+  step = step ?? 1;
   return (
     <>
       <span>{message}</span>
-      <Slider axis='x' xmax={max} xmin={min} x={value} onChange={({ x }) => setValue(x)} />({value})
+      <Slider axis='x' xstep={step} xmax={max} xmin={min} x={value} onChange={({ x }) => setValue(x)} />({value})
     </>
   );
 }

--- a/components/inputs/NumSlider.tsx
+++ b/components/inputs/NumSlider.tsx
@@ -15,7 +15,7 @@ function NumSlider({value, min, max, setValue, msg}: NumSelectorProps) {
   return (
     <>
       <span>{message}</span>
-      <Slider axis='x' xmax={max} xmin={min} x={value} onChange={({ x }) => setValue(x)} />
+      <Slider axis='x' xmax={max} xmin={min} x={value} onChange={({ x }) => setValue(x)} />({value})
     </>
   );
 }

--- a/components/inputs/NumSlider.tsx
+++ b/components/inputs/NumSlider.tsx
@@ -1,7 +1,5 @@
 import Slider from 'react-input-slider';
 
-import { setWeekTicks, useWeekTicks } from '../../hooks/useWeekTicks';
-
 interface NumSelectorProps {
   value: number;
   min: number;

--- a/components/roadmap-grid/Roadmap.module.css
+++ b/components/roadmap-grid/Roadmap.module.css
@@ -39,7 +39,6 @@
   text-align: center;
   font-size: 16px;
   font-weight: 600;
-  grid-column-end: span 4;
 }
 
 .nested > .item:not(.group) {
@@ -135,7 +134,6 @@ a.milestoneTitle {
   width: 2px;
   height: 20px;
   justify-self: center;
-  grid-column-end: span 4;
 }
 
 .timelineHeaderLine {

--- a/components/roadmap-grid/Roadmap.module.css
+++ b/components/roadmap-grid/Roadmap.module.css
@@ -49,6 +49,7 @@
   padding-right: 10px;
   margin-bottom: 4px;
   border-radius: 8px;
+  z-index: 5;
   /* min-height: 6rem; */
 }
 
@@ -144,38 +145,6 @@ a.milestoneTitle {
   background: revert !important;
   border-top: 1px solid;
   gap: 0px;
-}
-
-.todayMarker {
-  top: 23%;
-  position: absolute;
-  left: 60%;
-  height: 100%;
-  border: 1px rgba(0, 50, 255, 1);
-  border-style: dashed;
-  z-index: 3;
-  position: fixed;
-}
-
-.todayMarker::before {
-  white-space: nowrap;
-}
-
-.todayMarkerWrapper {
-  position: absolute;
-  left: 59%;
-}
-
-.todayMarkerText {
-  font-size: 14px;
-}
-
-.todayMarker.todayLine {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  border-left: thin solid #4a6792;
-  height: 0;
 }
 
 @media screen and (max-width: 600px) {

--- a/components/roadmap-grid/Roadmap.module.css
+++ b/components/roadmap-grid/Roadmap.module.css
@@ -3,6 +3,7 @@
   grid-gap: 0.5rem;
   grid-template-columns: repeat(10, minmax(10px, 1fr));
   margin-top: 15px;
+  overflow-x: hidden;
 }
 
 .scrollable {

--- a/components/roadmap-grid/Roadmap.module.css
+++ b/components/roadmap-grid/Roadmap.module.css
@@ -1,6 +1,7 @@
 .grid {
   display: grid;
   grid-gap: 0.5rem;
+  grid-column-gap: 0;
   grid-template-columns: repeat(10, minmax(10px, 1fr));
   margin-top: 15px;
   overflow-x: hidden;
@@ -40,6 +41,9 @@
   text-align: center;
   font-size: 16px;
   font-weight: 600;
+  position: relative;
+  /** must align with .timelineTick left positioning. This is done in order to handle the centering of the text and grid ticks*/
+  left: -1rem;
 }
 
 .nested > .item:not(.group) {
@@ -133,9 +137,10 @@ a.milestoneTitle {
 
 .timelineTick {
   background: #d5d5d5;
-  width: 2px;
-  height: 20px;
   justify-self: center;
+  position:relative;
+  /** must align with .itemHeader left positioning. This is done in order to handle the centering of the text and grid ticks*/
+  left: -1rem;
 }
 
 .timelineHeaderLine {

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -107,7 +107,7 @@ export function RoadmapDetailed({
                 <GroupItem group={group} />
                 {!!group.items &&
                   _.sortBy(group.items, ['title']).map((item, index) => {
-                    return <GridRow key={index} milestone={item} index={index} timelineTicks={ticksHeader} />;
+                    return <GridRow key={index} milestone={item} index={index} timelineTicks={ticksHeader} numGridCols={numGridCols} />;
                   })}
               </GroupWrapper>
             );

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -83,7 +83,7 @@ export function RoadmapDetailed({
   const globalScale = scaleTime().domain([dayjs.min(datesWithOffsetDayjs), dayjs.max(datesWithOffsetDayjs)]).range([0, numGridCols]);
   setGlobalTimeScale(globalScale);
 
-  // const ticks = getTicks(datesWithOffset, totalTimelineTicks - 1);
+  const ticks = getTicks(datesWithOffset, totalTimelineTicks - 1);
   const ticksHeader = getTicks(datesWithOffset, numHeaderTicks - 1);
 
   return (
@@ -107,7 +107,7 @@ export function RoadmapDetailed({
                 <GroupItem group={group} />
                 {!!group.items &&
                   _.sortBy(group.items, ['title']).map((item, index) => {
-                    return <GridRow key={index} milestone={item} index={index} timelineTicks={ticksHeader} numGridCols={numGridCols} />;
+                    return <GridRow key={index} milestone={item} index={index} timelineTicks={ticks} numGridCols={numGridCols} numHeaderItems={numHeaderTicks}/>;
                   })}
               </GroupWrapper>
             );

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -93,7 +93,7 @@ export function RoadmapDetailed({
   });
 
   const [numHeaderTicks, setNumHeaderTicks] = useState(5);
-  const [numGridCols, setNumGridCols] = useState((numHeaderTicks * 5));
+  const [numGridCols, setNumGridCols] = useState((numHeaderTicks * 12));
 
   globalTimeScaler.setScale(dates, numGridCols);
 
@@ -112,7 +112,7 @@ export function RoadmapDetailed({
             <GridHeader key={index} ticks={tick} index={index} numGridCols={numGridCols} />
           ))}
 
-          <Headerline numGridCols={numGridCols}/>
+          <Headerline numGridCols={numGridCols} ticksRatio={3}/>
         </Grid>
         <Grid ticksLength={numGridCols} scroll={true}  renderTodayLine={true} >
           {_.reverse(Array.from(_.sortBy(issuesGrouped, ['groupName']))).map((group, index) => {

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -93,9 +93,9 @@ export function RoadmapDetailed({
   });
 
   const [numHeaderTicks, setNumHeaderTicks] = useState(5);
-  const [numGridCols, setNumGridCols] = useState((numHeaderTicks * 12));
+  const [numGridCols, setNumGridCols] = useState(45);
 
-  globalTimeScaler.setScale(dates, numGridCols);
+  globalTimeScaler.setScale(dates, numGridCols * 1.09);
 
   const ticks = getTicks(dates, numGridCols - 1);
   const ticksHeader = getTicks(dates, numHeaderTicks - 1);
@@ -109,7 +109,7 @@ export function RoadmapDetailed({
         <Grid ticksLength={numGridCols}>
           {ticksHeader.map((tick, index) => (
 
-            <GridHeader key={index} ticks={tick} index={index} numGridCols={numGridCols} />
+            <GridHeader key={index} tick={tick} index={index} numHeaderTicks={numHeaderTicks} numGridCols={numGridCols} timeScaler={globalTimeScaler}/>
           ))}
 
           <Headerline numGridCols={numGridCols} ticksRatio={3}/>
@@ -121,7 +121,7 @@ export function RoadmapDetailed({
                 <GroupItem group={group} />
                 {!!group.items &&
                   _.sortBy(group.items, ['title']).map((item, index) => {
-                    return <GridRow key={index} milestone={item} index={index} timelineTicks={ticks} numGridCols={numGridCols} numHeaderItems={numHeaderTicks}/>;
+                    return <GridRow key={index} timeScaler={globalTimeScaler} milestone={item} index={index} timelineTicks={ticks} numGridCols={numGridCols} numHeaderItems={numHeaderTicks}/>;
                   })}
               </GroupWrapper>
             );

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -73,8 +73,8 @@ export function RoadmapDetailed({
   const today = dayjs();
   let dates = formatDateArrayDayJs(issuesGrouped.map((v) => v.items.map((v) => v.due_date)).flat())
     .concat([today.toDate()]).filter((v) => dayjs(v).isValid())
-  let minDate = dayjs.min([...dates.map(v => dayjs(v)), today.subtract(1, 'month')])
-  let maxDate = dayjs.max([...dates.map(v => dayjs(v)), today.add(1, 'month')])
+  let minDate = dayjs.min([...dates.map(dayjs), today.subtract(1, 'month')])
+  let maxDate = dayjs.max([...dates.map(dayjs), today.add(1, 'month')])
   let incrementMax = false
 
   while (maxDate.diff(minDate, 'months') < (3 * DEFAULT_TICK_COUNT)) {

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -89,7 +89,7 @@ export function RoadmapDetailed({
   return (
     <>
       <NumSlider msg="how many header ticks" value={numHeaderTicks} min={5} max={60} setValue={setNumHeaderTicks}/>
-      <NumSlider msg="how many grid columns" value={numGridCols} min={20} max={60} setValue={setNumGridCols}/>
+      <NumSlider msg="how many grid columns" value={numGridCols} min={20} max={60} step={numHeaderTicks} setValue={setNumGridCols}/>
 
       <Box className={styles.timelineBox}>
         <Grid ticksLength={numGridCols}>

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -95,10 +95,10 @@ export function RoadmapDetailed({
         <Grid ticksLength={numGridCols}>
           {ticksHeader.map((tick, index) => (
 
-            <GridHeader key={index} ticks={tick} index={index} />
+            <GridHeader key={index} ticks={tick} index={index} numGridCols={numGridCols} />
           ))}
 
-          <Headerline />
+          <Headerline numGridCols={numGridCols}/>
         </Grid>
         <Grid ticksLength={numGridCols} scroll={true}>
           {_.reverse(Array.from(_.sortBy(issuesGrouped, ['groupName']))).map((group, index) => {

--- a/components/roadmap-grid/grid-header.tsx
+++ b/components/roadmap-grid/grid-header.tsx
@@ -10,7 +10,7 @@ import styles from './Roadmap.module.css';
  * @param param0
  * @returns
  */
-export function GridHeader({ ticks, index }) {
+export function GridHeader({ ticks, index, numGridCols }) {
   const dateGranularity = useDateGranularity();
   const date = dayjs(ticks).utc();
 
@@ -30,7 +30,9 @@ export function GridHeader({ ticks, index }) {
   return (
 
     <ErrorBoundary>
-      <div key={index} className={`${styles.item} ${styles.itemHeader}`}>
+      <div key={index} className={`${styles.item} ${styles.itemHeader}`} style={{
+        gridColumnEnd: `span ${numGridCols / 5}`,
+      }}>
         <span>{label}</span>
       </div>
     </ErrorBoundary>

--- a/components/roadmap-grid/grid-header.tsx
+++ b/components/roadmap-grid/grid-header.tsx
@@ -29,7 +29,7 @@ export function GridHeader({ tick, index, numGridCols, timeScaler, numHeaderTick
       label = `Q${quarterNum}Q ${year}`;
     case DateGranularityState.Months:
     default:
-      label = date.format('DD MMMM YYYY');
+      label = date.format('DD MMM YYYY');
       break;
   }
 

--- a/components/roadmap-grid/grid-header.tsx
+++ b/components/roadmap-grid/grid-header.tsx
@@ -1,18 +1,24 @@
 import { useDateGranularity } from '../../hooks/useDateGranularity';
 import { dayjs } from '../../lib/client/dayjs';
+import { TimeScaler } from '../../lib/client/TimeScaler';
 import { DateGranularityState } from '../../lib/enums';
 import { ErrorBoundary } from '../errors/ErrorBoundary';
-
 import styles from './Roadmap.module.css';
 
+interface GridHeaderProps {
+  tick: Date;
+  index: number;
+  numGridCols: number;
+  timeScaler: TimeScaler;
+  numHeaderTicks: number;
+}
+
 /**
- * This is the labels for the grid. The quarters and the top with the ticks.
- * @param param0
- * @returns
+ * This is the labels for the grid. The quarters and the top with the tick.
  */
-export function GridHeader({ ticks, index, numGridCols }) {
+export function GridHeader({ tick, index, numGridCols, timeScaler, numHeaderTicks }: GridHeaderProps) {
   const dateGranularity = useDateGranularity();
-  const date = dayjs(ticks).utc();
+  const date = dayjs(tick).utc();
 
   let label = '';
   switch (dateGranularity) {
@@ -23,7 +29,7 @@ export function GridHeader({ ticks, index, numGridCols }) {
       label = `Q${quarterNum}Q ${year}`;
     case DateGranularityState.Months:
     default:
-      label = date.format('MMMM YYYY');
+      label = date.format('DD MMMM YYYY');
       break;
   }
 
@@ -31,7 +37,7 @@ export function GridHeader({ ticks, index, numGridCols }) {
 
     <ErrorBoundary>
       <div key={index} className={`${styles.item} ${styles.itemHeader}`} style={{
-        gridColumnEnd: `span ${numGridCols / 5}`,
+        gridColumnEnd: `span ${numGridCols / numHeaderTicks}`,
       }}>
         <span>{label}</span>
       </div>

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -7,7 +7,6 @@ import { IssueData } from '../../lib/types';
 import { getInternalLinkForIssue } from '../../lib/general';
 import styles from './Roadmap.module.css';
 import { SvgGitHubLogoWithTooltip } from '../icons/svgr/SvgGitHubLogoWithTooltip';
-import getDateAsQuarter from '../../lib/client/getDateAsQuarter';
 
 export function GridRow({
   milestone,
@@ -48,7 +47,12 @@ export function GridRow({
   const gridColumnEnd = closest === span ? closest : closest - 1
 
   if (span > gridColumnEnd) {
+    // TODO: Handle this error
     console.error('Span size is greater than gridColumnEnd', milestone)
+  }
+  if (closestDateIdx > numGridCols) {
+    // TODO: Handle this error
+    console.error('closestDateIdx is greater than numGridCols', milestone)
   }
 
   const rowItem = (

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -14,18 +14,20 @@ export function GridRow({
   index,
   timelineTicks,
   numGridCols,
+  numHeaderItems,
 }: {
   milestone: IssueData;
   index: number;
   timelineTicks: Date[];
   numGridCols: number;
+  numHeaderItems: number;
 }) {
   const closestDateIdx = getClosest({
-    currentDate: dayjs.utc(milestone.due_date).endOf('quarter').toDate(),
+    currentDate: dayjs.utc(milestone.due_date).toDate(),
     dates: timelineTicks,
-    totalTimelineTicks: timelineTicks.length,
+    totalTimelineTicks: numGridCols,
   });
-  const span = numGridCols / timelineTicks.length;
+  const span = Math.max(4, numGridCols / timelineTicks.length);
   const closest = span * (closestDateIdx - 1);
 
   const childLink = getInternalLinkForIssue(milestone);
@@ -53,8 +55,8 @@ export function GridRow({
     <div
       key={index}
       style={{
-        gridColumnStart: `span ${span}`,
-        gridColumnEnd: `${gridColumnEnd}`,
+        gridColumnStart: `span ${numGridCols / numHeaderItems}`,
+        gridColumnEnd: `${closestDateIdx}`,
         background: `linear-gradient(90deg, rgba(125, 224, 135, 0.6) ${parseInt(
           milestone.completion_rate.toString(2),
         )}%, white 0%, white ${100 - parseInt(milestone.completion_rate.toString(2))}%)`,

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -2,11 +2,11 @@ import NextLink from 'next/link';
 import { Flex, Spacer, Text } from '@chakra-ui/react';
 
 import { dayjs } from '../../lib/client/dayjs';
-import { getClosest } from '../../lib/client/getClosest';
 import { IssueData } from '../../lib/types';
 import { getInternalLinkForIssue } from '../../lib/general';
 import styles from './Roadmap.module.css';
 import { SvgGitHubLogoWithTooltip } from '../icons/svgr/SvgGitHubLogoWithTooltip';
+import { TimeScaler } from '../../lib/client/TimeScaler';
 
 export function GridRow({
   milestone,
@@ -14,18 +14,16 @@ export function GridRow({
   timelineTicks,
   numGridCols,
   numHeaderItems,
+  timeScaler
 }: {
   milestone: IssueData;
   index: number;
   timelineTicks: Date[];
   numGridCols: number;
   numHeaderItems: number;
+  timeScaler: TimeScaler;
 }) {
-  const closestDateIdx = getClosest({
-    currentDate: dayjs.utc(milestone.due_date).toDate(),
-    dates: timelineTicks,
-    totalTimelineTicks: numGridCols,
-  });
+  const closestDateIdx = Math.round(timeScaler.getColumn(dayjs.utc(milestone.due_date).toDate()));
   const span = Math.max(4, numGridCols / timelineTicks.length);
   const closest = span * (closestDateIdx - 1);
 
@@ -60,7 +58,7 @@ export function GridRow({
       key={index}
       style={{
         gridColumnStart: `span ${numGridCols / numHeaderItems}`,
-        gridColumnEnd: `${closestDateIdx - 1}`,
+        gridColumnEnd: `${closestDateIdx}`,
         background: `linear-gradient(90deg, rgba(125, 224, 135, 0.6) ${parseInt(
           milestone.completion_rate.toString(2),
         )}%, white 0%, white ${100 - parseInt(milestone.completion_rate.toString(2))}%)`,

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -60,7 +60,7 @@ export function GridRow({
       key={index}
       style={{
         gridColumnStart: `span ${numGridCols / numHeaderItems}`,
-        gridColumnEnd: `${closestDateIdx}`,
+        gridColumnEnd: `${closestDateIdx - 1}`,
         background: `linear-gradient(90deg, rgba(125, 224, 135, 0.6) ${parseInt(
           milestone.completion_rate.toString(2),
         )}%, white 0%, white ${100 - parseInt(milestone.completion_rate.toString(2))}%)`,

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -13,17 +13,19 @@ export function GridRow({
   milestone,
   index,
   timelineTicks,
+  numGridCols,
 }: {
   milestone: IssueData;
   index: number;
   timelineTicks: Date[];
+  numGridCols: number;
 }) {
   const closestDateIdx = getClosest({
     currentDate: dayjs.utc(milestone.due_date).endOf('quarter').toDate(),
     dates: timelineTicks,
     totalTimelineTicks: timelineTicks.length,
   });
-  const span = 4;
+  const span = numGridCols / timelineTicks.length;
   const closest = span * (closestDateIdx - 1);
 
   const childLink = getInternalLinkForIssue(milestone);
@@ -41,12 +43,18 @@ export function GridRow({
       return null;
     }
   }
+  const gridColumnEnd = closest === span ? closest : closest - 1
+
+  if (span > gridColumnEnd) {
+    console.error('Span size is greater than gridColumnEnd', milestone)
+  }
+
   const rowItem = (
     <div
       key={index}
       style={{
         gridColumnStart: `span ${span}`,
-        gridColumnEnd: `${closest === span ? closest : closest - 1}`,
+        gridColumnEnd: `${gridColumnEnd}`,
         background: `linear-gradient(90deg, rgba(125, 224, 135, 0.6) ${parseInt(
           milestone.completion_rate.toString(2),
         )}%, white 0%, white ${100 - parseInt(milestone.completion_rate.toString(2))}%)`,

--- a/components/roadmap-grid/grid.tsx
+++ b/components/roadmap-grid/grid.tsx
@@ -1,12 +1,11 @@
 import styles from './Roadmap.module.css';
-import {RemoveScrollBar} from 'react-remove-scroll-bar';
 import { TodayMarker } from './today-marker';
 
-export function Grid({ children, ticksLength, scroll = false }) {
+export function Grid({ children, ticksLength, scroll = false, renderTodayLine = false}) {
   const styleClass = scroll ? styles.scrollable : styles.grid;
   return (
     <div className={styleClass} style={{ gridTemplateColumns: `repeat(${ticksLength}, minmax(10px, 1fr))` }}>
-      {/* <TodayMarker /> */}
+      {renderTodayLine ? <TodayMarker /> : null}
       {children}
     </div>
   );

--- a/components/roadmap-grid/headerline.tsx
+++ b/components/roadmap-grid/headerline.tsx
@@ -3,13 +3,20 @@ import { GridItem } from '@chakra-ui/react';
 import styles from './Roadmap.module.css';
 import { GroupWrapper } from './group-wrapper';
 
-export function Headerline({ numGridCols }) {
+interface HeaderlineProps {
+  numGridCols: number;
+  ticksRatio?: number
+}
+export function Headerline({ numGridCols, ticksRatio = 1 }: HeaderlineProps) {
   const numberOfHeaderItems = 5;
-  const headerItems = Array.from({ length: numberOfHeaderItems }, (_, i) => (
-    <div key={i} className={styles.timelineTick} style={{
-      gridColumnEnd: `span ${numGridCols / numberOfHeaderItems}`,
-    }}/>
-  ));
+  const headerItems = Array.from({ length: numberOfHeaderItems * ticksRatio }, (_, i) => {
+    console.log(`Header tick ${i}: numGridCols(${numGridCols}), numberOfHeaderItems(${numberOfHeaderItems}) = `, numGridCols / numberOfHeaderItems);
+    return (
+      <div key={i} className={styles.timelineTick} style={{
+        gridColumnEnd: `span ${numGridCols / numberOfHeaderItems / ticksRatio}`,
+      }}/>
+    )
+  });
 
   return (
     <GroupWrapper cssName='timelineHeaderLineWrapper'>

--- a/components/roadmap-grid/headerline.tsx
+++ b/components/roadmap-grid/headerline.tsx
@@ -3,15 +3,18 @@ import { GridItem } from '@chakra-ui/react';
 import styles from './Roadmap.module.css';
 import { GroupWrapper } from './group-wrapper';
 
-export function Headerline() {
+export function Headerline({ numGridCols }) {
+  const numberOfHeaderItems = 5;
+  const headerItems = Array.from({ length: numberOfHeaderItems }, (_, i) => (
+    <div key={i} className={styles.timelineTick} style={{
+      gridColumnEnd: `span ${numGridCols / numberOfHeaderItems}`,
+    }}/>
+  ));
+
   return (
     <GroupWrapper cssName='timelineHeaderLineWrapper'>
       <GridItem style={{ gridRowStart: '2', gridRowEnd: 'span 1' }} className={styles.timelineHeaderLine} />
-      <div className={styles.timelineTick}></div>
-      <div className={styles.timelineTick}></div>
-      <div className={styles.timelineTick}></div>
-      <div className={styles.timelineTick}></div>
-      <div className={styles.timelineTick}></div>
+      {headerItems}
     </GroupWrapper>
   );
 }

--- a/components/roadmap-grid/headerline.tsx
+++ b/components/roadmap-grid/headerline.tsx
@@ -1,4 +1,4 @@
-import { GridItem } from '@chakra-ui/react';
+import { Center, GridItem } from '@chakra-ui/react';
 
 import styles from './Roadmap.module.css';
 import { GroupWrapper } from './group-wrapper';
@@ -9,12 +9,22 @@ interface HeaderlineProps {
 }
 export function Headerline({ numGridCols, ticksRatio = 1 }: HeaderlineProps) {
   const numberOfHeaderItems = 5;
-  const headerItems = Array.from({ length: numberOfHeaderItems * ticksRatio }, (_, i) => {
-    console.log(`Header tick ${i}: numGridCols(${numGridCols}), numberOfHeaderItems(${numberOfHeaderItems}) = `, numGridCols / numberOfHeaderItems);
+  const firstLabeledTick = 2;
+  const headerItems = Array.from({ length: numberOfHeaderItems * ticksRatio + 1 }, (_, i) => {
+    const gridColumnEnd = numGridCols / numberOfHeaderItems / ticksRatio
+
+    const isTaller = i === firstLabeledTick || i !== 0 && (i-firstLabeledTick) % ticksRatio === 0 ? true : false
+
+    if (i === 0) {
+      return null;
+    }
+
     return (
       <div key={i} className={styles.timelineTick} style={{
-        gridColumnEnd: `span ${numGridCols / numberOfHeaderItems / ticksRatio}`,
-      }}/>
+        gridColumnEnd: `span ${gridColumnEnd}`,
+        height: isTaller ? '20px' : '10px',
+        width: isTaller ? '2px' : '1px',
+      }}></div>
     )
   });
 

--- a/components/roadmap-grid/today-marker.module.css
+++ b/components/roadmap-grid/today-marker.module.css
@@ -1,0 +1,35 @@
+
+.todayMarkerWrapper {
+  position: absolute;
+}
+
+.todayMarker {
+  position: relative;
+  height: 100%;
+  border: 1px #4a6792;
+  border-style: dashed;
+  z-index: 3;
+  position: fixed;
+}
+
+.todayMarker::before {
+  white-space: nowrap;
+}
+
+.todayMarkerText {
+  font-size: 14px;
+  position:absolute;
+  z-index: 6;
+  font-weight: 900;
+  background-color: rgba(215, 228, 253, 0.5);
+  top: -20px;
+  padding: 0.5rem;
+}
+
+.todayMarker.todayLine {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  border-left: thin solid #4a6792;
+  height: 0;
+}

--- a/components/roadmap-grid/today-marker.module.css
+++ b/components/roadmap-grid/today-marker.module.css
@@ -1,6 +1,7 @@
 
 .todayMarkerWrapper {
   position: absolute;
+  height: 50em;
 }
 
 .todayMarker {
@@ -9,7 +10,8 @@
   border: 1px #4a6792;
   border-style: dashed;
   z-index: 3;
-  position: fixed;
+  position: relative;
+  width: 1px;
 }
 
 .todayMarker::before {

--- a/components/roadmap-grid/today-marker.module.css
+++ b/components/roadmap-grid/today-marker.module.css
@@ -6,12 +6,14 @@
 
 .todayMarker {
   position: relative;
-  height: 100%;
-  border: 1px #4a6792;
-  border-style: dashed;
+  height: 60em;
+  /* TODO: Waiting to match the rest of the figma styles */
+  /* border: 2px solid #1FA5FF; */
+  border: 1px dashed #4a6792;
   z-index: 3;
   position: relative;
   width: 1px;
+  top: -3rem;
 }
 
 .todayMarker::before {
@@ -21,11 +23,16 @@
 .todayMarkerText {
   font-size: 14px;
   position:absolute;
+  /* TODO: Waiting to match the rest of the figma styles */
+  /* color: #F39106; */
+  color: #1FA5FF;
   z-index: 6;
   font-weight: 900;
-  background-color: rgba(215, 228, 253, 0.4);
-  top: -30px;
+  top: -5rem;
   padding: 0.5rem;
+  font-weight: 700;
+  font-size: 19px;
+  line-height: 19px;
 }
 
 .todayMarker.todayLine {

--- a/components/roadmap-grid/today-marker.module.css
+++ b/components/roadmap-grid/today-marker.module.css
@@ -23,8 +23,8 @@
   position:absolute;
   z-index: 6;
   font-weight: 900;
-  background-color: rgba(215, 228, 253, 0.5);
-  top: -20px;
+  background-color: rgba(215, 228, 253, 0.4);
+  top: -30px;
   padding: 0.5rem;
 }
 

--- a/components/roadmap-grid/today-marker.module.css
+++ b/components/roadmap-grid/today-marker.module.css
@@ -9,7 +9,7 @@
   height: 60em;
   /* TODO: Waiting to match the rest of the figma styles */
   /* border: 2px solid #1FA5FF; */
-  border: 1px dashed #4a6792;
+  border: 1px dashed #F39106;
   z-index: 3;
   position: relative;
   width: 1px;
@@ -25,7 +25,7 @@
   position:absolute;
   /* TODO: Waiting to match the rest of the figma styles */
   /* color: #F39106; */
-  color: #1FA5FF;
+  color: #F39106;
   z-index: 6;
   font-weight: 900;
   top: -5rem;

--- a/components/roadmap-grid/today-marker.tsx
+++ b/components/roadmap-grid/today-marker.tsx
@@ -18,7 +18,7 @@ export function TodayMarker() {
         left: `${percentLeft}%`,
     }}>
       {isLineVisible ? <div className={styles.todayMarker} /> : null}
-      <Center cursor="pointer" onClick={() => setIsLineVisible(!isLineVisible)}><div className={styles.todayMarkerText}>Today</div></Center>
+      <Center cursor="pointer" onClick={() => setIsLineVisible(!isLineVisible)}><div className={styles.todayMarkerText}>TODAY</div></Center>
     </div>
   );
 }

--- a/components/roadmap-grid/today-marker.tsx
+++ b/components/roadmap-grid/today-marker.tsx
@@ -1,10 +1,24 @@
-import styles from './Roadmap.module.css';
+import { Center } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+
+import { globalTimeScaler } from '../../lib/client/TimeScaler';
+import styles from './today-marker.module.css';
 
 export function TodayMarker() {
+  const getPercentLeft = (): Number => Number((globalTimeScaler.getPercentile(new Date()) * 100).toFixed(2));
+  const [percentLeft, setPercentLeft] = useState(getPercentLeft());
+  const [isLineVisible, setIsLineVisible] = useState(true);
+
+  useEffect(() => {
+    setPercentLeft(getPercentLeft());
+  }, [getPercentLeft, setPercentLeft, globalTimeScaler.percentageScale]);
+
   return (
-    <div className={styles.todayMarkerWrapper}>
-      <div className={styles.todayMarker} style={{ gridColumn: '1/-1' }} />
-      <div className={styles.todayMarkerText}>Today</div>
+    <div className={styles.todayMarkerWrapper} style={{
+        left: `${percentLeft}%`,
+    }}>
+      {isLineVisible ? <div className={styles.todayMarker} /> : null}
+      <Center cursor="pointer" onClick={() => setIsLineVisible(!isLineVisible)}><div className={styles.todayMarkerText}>Today</div></Center>
     </div>
   );
 }

--- a/hooks/useGlobalTimeScale.ts
+++ b/hooks/useGlobalTimeScale.ts
@@ -3,6 +3,6 @@ import { useState } from 'react';
 
 import useSharedHook from '../lib/client/createSharedHook';
 
-const [useGlobalTimeScale, setGlobalTimeScale] = useSharedHook<ScaleTime<Date, number> | null>(useState, null);
+const [useGlobalTimeScale, setGlobalTimeScale] = useSharedHook<ScaleTime<number, number> | null>(useState, null);
 
 export { useGlobalTimeScale, setGlobalTimeScale };

--- a/hooks/useGlobalTimeScale.ts
+++ b/hooks/useGlobalTimeScale.ts
@@ -1,0 +1,8 @@
+import { ScaleTime } from 'd3';
+import { useState } from 'react';
+
+import useSharedHook from '../lib/client/createSharedHook';
+
+const [useGlobalTimeScale, setGlobalTimeScale] = useSharedHook<ScaleTime<Date, number> | null>(useState, null);
+
+export { useGlobalTimeScale, setGlobalTimeScale };

--- a/lib/client/TimeScaler.ts
+++ b/lib/client/TimeScaler.ts
@@ -1,0 +1,35 @@
+import { ScaleTime, scaleTime } from 'd3';
+
+import { dayjs } from './dayjs';
+
+/**
+ * TODO: Implement using React Provider pattern
+ */
+export class TimeScaler {
+  gridColScale: ScaleTime<number, number>;
+  percentageScale: ScaleTime<number, number>;
+  constructor() {
+    this.percentageScale = scaleTime();
+    this.gridColScale = scaleTime();
+  }
+
+  setScale(dates: Date[], numCols: number) {
+    const validDates = dates.map(dayjs).filter((d) => d.isValid())
+    const minDate = dayjs.min(validDates);
+    const maxDate = dayjs.max(validDates);
+    const domain = [minDate, maxDate];
+    this.percentageScale = scaleTime().domain(domain).range([0, 1]);
+    this.gridColScale = scaleTime().domain(domain).range([0, numCols]);
+  }
+
+  getPercentile(date: Date) {
+    return this.percentageScale(date)
+  }
+
+  getColumn(date: Date) {
+    return this.gridColScale(date)
+  }
+}
+
+
+export const globalTimeScaler = new TimeScaler();

--- a/lib/client/getTicks.ts
+++ b/lib/client/getTicks.ts
@@ -1,30 +1,13 @@
 import { utcTicks } from 'd3';
 
 import { dayjs } from './dayjs';
-import { DEFAULT_TICK_COUNT } from '../../config/constants';
 import { getQuantiles } from './getQuantiles';
 
 const getTicks = (dates: Date[], totalTicks) => {
   const count = totalTicks;
   let utcDates = dates.map((date) => dayjs(date).utc()).filter((date) => date.isValid());
-  if (utcDates.length === 0) {
-    utcDates = [dayjs().subtract(1, 'month').utc(), dayjs().add(1, 'month').utc()];
-  }
   let min = dayjs.min(utcDates);
   let max = dayjs.max(utcDates);
-
-  let incrementMax = false;
-  /**
-   * TODO: Need to update this to support date granularity
-   */
-  while (max.diff(min, 'months') < (3 * DEFAULT_TICK_COUNT)) {
-    if (incrementMax) {
-      max = max.add(1, 'quarter');
-    } else {
-      min = min.subtract(1, 'quarter');
-    }
-    incrementMax = !incrementMax;
-  }
 
   const ticks = utcTicks(min.toDate(), max.toDate(), count);
   const quantiles = getQuantiles(ticks, totalTicks);

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -8,6 +8,8 @@ import NewRoadmap from '../../components/roadmap/NewRoadmap';
 import { API_URL } from '../../config/constants';
 import { IssueData, RoadmapApiResponse, RoadmapApiResponseFailure, RoadmapApiResponseSuccess, ServerSidePropsResult } from '../../lib/types';
 import { ErrorNotificationDisplay } from '../../components/errors/ErrorNotificationDisplay';
+import NumSlider from '../../components/inputs/NumSlider';
+import { useState } from 'react';
 
 export async function getServerSideProps(context): Promise<ServerSidePropsResult> {
   const [hostname, owner, repo, issues_placeholder, issue_number] = context.query.slug;

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -9,7 +9,7 @@ import { API_URL } from '../../config/constants';
 import { IssueData, RoadmapApiResponse, RoadmapApiResponseFailure, RoadmapApiResponseSuccess, ServerSidePropsResult } from '../../lib/types';
 import { ErrorNotificationDisplay } from '../../components/errors/ErrorNotificationDisplay';
 import NumSlider from '../../components/inputs/NumSlider';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export async function getServerSideProps(context): Promise<ServerSidePropsResult> {
   const [hostname, owner, repo, issues_placeholder, issue_number] = context.query.slug;


### PR DESCRIPTION
- feat: create global scaleTime hook
- feat: add NumSelector slider component
- tmp
- feat: make header grid-column-end dynamic
- feat: ensure milestone item width is adjustable
- feat: display current value in NumSlider
- chore: remove unused code
- feat: make gridCol changes smoother
- chore: fix accuracy of milestone items

Fixes #135. 
fixes #34 

A few changes to the way roadmaps are rendered:

1. Header and positioning does not jump when toggling between Overview and Detailed view 
2. Roadmaps are no longer centered on Todays date. Roadmaps are centered to a view that contains all provided dates.
    * Today line is visible now to compensate for this. @juliaxbow I can remove this if it's not ideal and we can iterate later
    * "Today" text can be clicked to hide the line if desired.
3. Whether milestones have multiple children or not, they're all rendered accurately
    * Dev note: this is handled via a new `TimeScaler` class singleton.. but should probably be implemented via react context & Provider pattern
    * We still have some older code that has 'months'/'weeks'/'quarters' hardcoded, and we need to address that, but I was mostly targeting accuracy and monthly timeScale with this fix. #153 should address any bugs that come up between quarterly/monthly 

# Tested roadmaps

## Looking good
* http://localhost:3000/roadmap/github.com/filecoin-project/rust-fil-proofs/issues/1644 (multiple children)
* http://localhost:3000/roadmap/github.com/filecoin-project/bacalhau/issues/1151 (many children)
* http://localhost:3000/roadmap/github.com/filecoin-station/roadmap/issues/1 (single child)

## Needs work
* N/A ?
