### PR TITLE
fix: removing additional set state

### DIFF
--- a/components/roadmap-grid/RoadmapTabbedView.tsx
+++ b/components/roadmap-grid/RoadmapTabbedView.tsx
@@ -7,6 +7,7 @@ import {
   Tabs
 } from '@chakra-ui/react';
 import { setViewMode, useViewMode } from '../../hooks/useViewMode';
+import { DEFAULT_INITIAL_VIEW_MODE } from '../../lib/defaults';
 import { ViewMode } from '../../lib/enums';
 import { IssueData } from '../../lib/types';
 import Header from './header';
@@ -14,7 +15,7 @@ import styles from './Roadmap.module.css';
 import { RoadmapDetailed } from './RoadmapDetailedView';
 
 export function RoadmapTabbedView({ issueData }: { issueData: IssueData; }) {
-  const viewMode = useViewMode() || ViewMode.Simple;
+  const viewMode = useViewMode() || DEFAULT_INITIAL_VIEW_MODE;
   // Defining what tabs to show and in what order
   const tabs = ['Overview', 'Detailed View'] as const;
 

--- a/components/roadmap-grid/RoadmapTabbedView.tsx
+++ b/components/roadmap-grid/RoadmapTabbedView.tsx
@@ -14,7 +14,7 @@ import styles from './Roadmap.module.css';
 import { RoadmapDetailed } from './RoadmapDetailedView';
 
 export function RoadmapTabbedView({ issueData }: { issueData: IssueData; }) {
-  const viewMode = useViewMode();
+  const viewMode = useViewMode() || ViewMode.Simple;
   // Defining what tabs to show and in what order
   const tabs = ['Overview', 'Detailed View'] as const;
 

--- a/components/roadmap-grid/RoadmapTabbedView.tsx
+++ b/components/roadmap-grid/RoadmapTabbedView.tsx
@@ -6,7 +6,6 @@ import {
   TabPanels,
   Tabs
 } from '@chakra-ui/react';
-import { useState } from 'react';
 import { setViewMode, useViewMode } from '../../hooks/useViewMode';
 import { ViewMode } from '../../lib/enums';
 import { IssueData } from '../../lib/types';
@@ -24,17 +23,17 @@ export function RoadmapTabbedView({ issueData }: { issueData: IssueData; }) {
     'Overview': ViewMode.Simple,
     'Detailed View': ViewMode.Detail,
   };
-  const tabViewMapInverse: Record<ViewMode, number> = {
-    [ViewMode.Simple]: 0,
-    [ViewMode.Detail]: 1,
-  };
+
+  // Mapping the tabs to the views
+  const tabViewMapInverse: Record<ViewMode, number> = tabs.reduce((acc, tab, index) => {
+    acc[tabViewMap[tab]] = index;
+    return acc;
+  }, {} as Record<ViewMode, number>);
 
   const tabIndexFromViewMode = tabViewMapInverse[viewMode]
-  const [_tabIndex, setTabIndex] = useState(tabIndexFromViewMode);
 
   const handleTabChange = (index: number) => {
     setViewMode(tabViewMap[tabs[index]]);
-    setTabIndex(index)
   }
 
   const renderTab = (title: string, index: number) => (

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -39,6 +39,7 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    */
   useEffect(() => {
     if (localStorageValue != null && state !== localStorageValue) {
+      console.log(`setting state to ${localStorageValue}`)
       setState(localStorageValue);
     }
   }, [state, setState, localStorageValue]);
@@ -48,7 +49,6 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * @param {S} newState - the new value to set
    */
   const setCachedState = (newState: S) => {
-    setState(newState);
     setLocalStorageValue(newState);
   };
 

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -7,20 +7,15 @@ const LOCAL_STORAGE_CACHE_KEY = 'useViewModeCache'
 const DEFAULT_INITIAL_VIEW_MODE = ViewMode.Simple;
 
 const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?: S) => {
-
   const [state, setState] = useState(initialState);
-
-  const parseValueFromStorage = (persistedValue: string | null) => {
-    const actualPersistedValue = JSON.parse(persistedValue ?? '""');
-    return actualPersistedValue;
-  };
 
   /**
    * Update the saved localStorage value to equal the current localStorage State
    * value if the values are in sync.
    */
   useEffect(() => {
-    const actualPersistedValue = parseValueFromStorage(localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY));
+    const persistedValue = localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY);
+    const actualPersistedValue = JSON.parse(persistedValue ?? '""');
     if (!state) {
       const initialStateFromStorage = actualPersistedValue === '' ? DEFAULT_INITIAL_VIEW_MODE : actualPersistedValue;
       setState(initialStateFromStorage);
@@ -35,7 +30,8 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * Update the actual viewMode value if it is different from what is in localStorage
    */
   useEffect(() => {
-    const actualPersistedValue = parseValueFromStorage(localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY));
+    const persistedValue = localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY);
+    const actualPersistedValue = JSON.parse(persistedValue ?? '""');
     if (actualPersistedValue !== state) {
       setState(actualPersistedValue);
     }

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -29,7 +29,6 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * value if the values are in sync.
    */
   useEffect(() => {
-
     if (localStorage != null && state === localStorageValue) {
       localStorage.setItem(LOCAL_STORAGE_CACHE_KEY, JSON.stringify(localStorageValue));
     }
@@ -39,7 +38,7 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * Update the actual viewMode value if it is different from what is in localStorage
    */
   useEffect(() => {
-    if (localStorageValue != null && localStorageValue !== state) {
+    if (localStorageValue != null && state !== localStorageValue) {
       setState(localStorageValue);
     }
   }, [state, setState, localStorageValue]);
@@ -49,6 +48,7 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * @param {S} newState - the new value to set
    */
   const setCachedState = (newState: S) => {
+    setState(newState);
     setLocalStorageValue(newState);
   };
 

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -10,8 +10,7 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
 
   const [state, setState] = useState(initialState);
 
-  const getCurrentValueFromStorage = () => {
-    const persistedValue = localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY);
+  const parseValueFromStorage = (persistedValue: string | null) => {
     const actualPersistedValue = JSON.parse(persistedValue ?? '""');
     return actualPersistedValue;
   };
@@ -21,7 +20,7 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * value if the values are in sync.
    */
   useEffect(() => {
-    const actualPersistedValue = getCurrentValueFromStorage();
+    const actualPersistedValue = parseValueFromStorage(localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY));
     if (!state) {
       const initialStateFromStorage = actualPersistedValue === '' ? DEFAULT_INITIAL_VIEW_MODE : actualPersistedValue;
       setState(initialStateFromStorage);
@@ -36,7 +35,7 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * Update the actual viewMode value if it is different from what is in localStorage
    */
   useEffect(() => {
-    const actualPersistedValue = getCurrentValueFromStorage();
+    const actualPersistedValue = parseValueFromStorage(localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY));
     if (actualPersistedValue !== state) {
       setState(actualPersistedValue);
     }

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -13,13 +13,18 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    */
   const [localStorageValue, setLocalStorageValue] = useState<S | null>(null);
 
+  const getCurrentValueFromStorage = () => {
+    const cachedValue = localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY);
+    const actualCachedValue = JSON.parse(cachedValue ?? '""');
+    return actualCachedValue;
+  }
+
   /**
    * Update localStorageValue to equal what is in localStorage
    */
   useEffect(() => {
-    if (localStorage != null) {
-      const cachedValue = localStorage.getItem(LOCAL_STORAGE_CACHE_KEY);
-      const actualCachedValue = cachedValue != null ? JSON.parse(cachedValue) : null;
+    const actualCachedValue = getCurrentValueFromStorage();
+    if (actualCachedValue !== '' && localStorageValue !== actualCachedValue) {
       setLocalStorageValue(actualCachedValue);
     }
   }, [setLocalStorageValue])
@@ -29,8 +34,9 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    * value if the values are in sync.
    */
   useEffect(() => {
-    if (localStorage != null && state === localStorageValue) {
-      localStorage.setItem(LOCAL_STORAGE_CACHE_KEY, JSON.stringify(localStorageValue));
+    const actualCachedValue = getCurrentValueFromStorage();
+    if (actualCachedValue !== state && state === localStorageValue) {
+      localStorage?.setItem(LOCAL_STORAGE_CACHE_KEY, JSON.stringify(localStorageValue));
     }
   }, [state, localStorageValue])
 

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -45,7 +45,7 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    */
   useEffect(() => {
     if (localStorageValue != null && state !== localStorageValue) {
-      console.log(`setting state to ${localStorageValue}`)
+      console.log(`setting state to`, { localStorageValue, state }),
       setState(localStorageValue);
     }
   }, [state, setState, localStorageValue]);

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -50,7 +50,6 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
    */
   const setCachedState = (newState: S) => {
     setLocalStorageValue(newState);
-    setState(newState);
   };
 
   if (typeof initialState === 'undefined') {

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -43,6 +43,6 @@ const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?
   return [state, setState] as [S | undefined, Dispatch<SetStateAction<S | undefined>>];
 }
 
-const [useViewMode, setViewMode] = useSharedHook(customStateFunction, undefined);
+const [useViewMode, setViewMode] = useSharedHook(customStateFunction, undefined as ViewMode | undefined);
 
 export { useViewMode, setViewMode };

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -4,66 +4,50 @@ import useSharedHook from '../lib/client/createSharedHook';
 import { ViewMode } from '../lib/enums';
 
 const LOCAL_STORAGE_CACHE_KEY = 'useViewModeCache'
+const DEFAULT_INITIAL_VIEW_MODE = ViewMode.Simple;
+
 const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?: S) => {
 
   const [state, setState] = useState(initialState);
-  /**
-   * We should only access localStorage inside useEffect because otherwise nextjs
-   * will try to use it on the server and it will fail.
-   */
-  const [localStorageValue, setLocalStorageValue] = useState<S | null>(null);
 
   const getCurrentValueFromStorage = () => {
-    const cachedValue = localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY);
-    const actualCachedValue = JSON.parse(cachedValue ?? '""');
-    return actualCachedValue;
-  }
-
-  /**
-   * Update localStorageValue to equal what is in localStorage
-   */
-  useEffect(() => {
-    const actualCachedValue = getCurrentValueFromStorage();
-    if (actualCachedValue !== '' && localStorageValue !== actualCachedValue) {
-      setLocalStorageValue(actualCachedValue);
-    }
-  }, [setLocalStorageValue])
+    const persistedValue = localStorage?.getItem(LOCAL_STORAGE_CACHE_KEY);
+    const actualPersistedValue = JSON.parse(persistedValue ?? '""');
+    return actualPersistedValue;
+  };
 
   /**
    * Update the saved localStorage value to equal the current localStorage State
    * value if the values are in sync.
    */
   useEffect(() => {
-    const actualCachedValue = getCurrentValueFromStorage();
-    if (actualCachedValue !== state && state === localStorageValue) {
-      localStorage?.setItem(LOCAL_STORAGE_CACHE_KEY, JSON.stringify(localStorageValue));
+    const actualPersistedValue = getCurrentValueFromStorage();
+    if (!state) {
+      const initialStateFromStorage = actualPersistedValue === '' ? DEFAULT_INITIAL_VIEW_MODE : actualPersistedValue;
+      setState(initialStateFromStorage);
+    } else {
+      if (actualPersistedValue !== state) {
+        localStorage?.setItem(LOCAL_STORAGE_CACHE_KEY, JSON.stringify(state));
+      }
     }
-  }, [state, localStorageValue])
+  }, [state])
 
   /**
    * Update the actual viewMode value if it is different from what is in localStorage
    */
   useEffect(() => {
-    if (localStorageValue != null && state !== localStorageValue) {
-      console.log(`setting state to`, { localStorageValue, state }),
-      setState(localStorageValue);
+    const actualPersistedValue = getCurrentValueFromStorage();
+    if (actualPersistedValue !== state) {
+      setState(actualPersistedValue);
     }
-  }, [state, setState, localStorageValue]);
-
-  /**
-   * Update both the actual viewMode value and the localStorage value
-   * @param {S} newState - the new value to set
-   */
-  const setCachedState = (newState: S) => {
-    setLocalStorageValue(newState);
-  };
+  }, [state]);
 
   if (typeof initialState === 'undefined') {
-    return [state, setCachedState] as [S, Dispatch<SetStateAction<S>>];
+    return [state, setState] as [S, Dispatch<SetStateAction<S>>];
   }
-  return [state, setCachedState] as [S | undefined, Dispatch<SetStateAction<S | undefined>>];
+  return [state, setState] as [S | undefined, Dispatch<SetStateAction<S | undefined>>];
 }
 
-const [useViewMode, setViewMode] = useSharedHook(customStateFunction, ViewMode.Simple);
+const [useViewMode, setViewMode] = useSharedHook(customStateFunction, undefined);
 
 export { useViewMode, setViewMode };

--- a/hooks/useViewMode.ts
+++ b/hooks/useViewMode.ts
@@ -1,10 +1,10 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 import useSharedHook from '../lib/client/createSharedHook';
+import { DEFAULT_INITIAL_VIEW_MODE } from '../lib/defaults';
 import { ViewMode } from '../lib/enums';
 
 const LOCAL_STORAGE_CACHE_KEY = 'useViewModeCache'
-const DEFAULT_INITIAL_VIEW_MODE = ViewMode.Simple;
 
 const customStateFunction: typeof useState = <S = typeof ViewMode>(initialState?: S) => {
   const [state, setState] = useState(initialState);

--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -1,0 +1,3 @@
+import { ViewMode } from "./enums";
+
+export const DEFAULT_INITIAL_VIEW_MODE = ViewMode.Simple;


### PR DESCRIPTION
Closes: #99 

This fixes the weird `localStorage` behaviour 🤞🏽 

RCA:
- The value seems to change and then quickly revert back to the previous. This likely happens because the both functions are not setting the same value.
- IRL we don't need to `setState` the second time.