### PR TITLE
chore: break-up roadmap.ts

### DIFF
--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * @see https://usehooks.com/useAsync/
+ */
+export const useAsync = <T, E = string>(
+  asyncFunction: () => Promise<T>,
+  immediate = true
+) => {
+  const [status, setStatus] = useState<
+    "idle" | "pending" | "success" | "error"
+  >("idle");
+  const [value, setValue] = useState<T | null>(null);
+  const [error, setError] = useState<E | null>(null);
+  // The execute function wraps asyncFunction and
+  // handles setting state for pending, value, and error.
+  // useCallback ensures the below useEffect is not called
+  // on every render, but only if asyncFunction changes.
+  const execute = useCallback(() => {
+    setStatus("pending");
+    setValue(null);
+    setError(null);
+    return asyncFunction()
+      .then((response: any) => {
+        setValue(response);
+        setStatus("success");
+      })
+      .catch((error: any) => {
+        setError(error);
+        setStatus("error");
+      });
+  }, [asyncFunction]);
+  // Call execute if we want to fire it right away.
+  // Otherwise execute can be called later, such as
+  // in an onClick handler.
+  useEffect(() => {
+    if (immediate) {
+      execute();
+    }
+  }, [execute, immediate]);
+  return { execute, status, value, error };
+};

--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -16,19 +16,18 @@ export const useAsync = <T, E = string>(
   // handles setting state for pending, value, and error.
   // useCallback ensures the below useEffect is not called
   // on every render, but only if asyncFunction changes.
-  const execute = useCallback(() => {
+  const execute = useCallback(async () => {
     setStatus("pending");
     setValue(null);
     setError(null);
-    return asyncFunction()
-      .then((response: any) => {
+    try {
+        const response = await asyncFunction();
         setValue(response);
         setStatus("success");
-      })
-      .catch((error: any) => {
+    } catch(error: any) {
         setError(error);
         setStatus("error");
-      });
+    }
   }, [asyncFunction]);
   // Call execute if we want to fire it right away.
   // Otherwise execute can be called later, such as

--- a/lib/backend/addToChildren.ts
+++ b/lib/backend/addToChildren.ts
@@ -1,0 +1,28 @@
+import { getDueDate } from '../parser';
+import { GithubIssueDataWithGroupAndChildren, IssueData } from '../types';
+import { calculateCompletionRate } from './calculateCompletionRate';
+
+export function addToChildren(
+  data: GithubIssueDataWithGroupAndChildren[],
+  parent: IssueData | GithubIssueDataWithGroupAndChildren
+): IssueData[] {
+  if (Array.isArray(data)) {
+    return data.map((item: GithubIssueDataWithGroupAndChildren): IssueData => ({
+      labels: item.labels ?? [],
+      completion_rate: calculateCompletionRate(item),
+      due_date: getDueDate(item).eta,
+      html_url: item.html_url,
+      group: item.group,
+      title: item.title,
+      state: item.state,
+      node_id: item.node_id,
+      body: item.body,
+      body_html: item.body_html,
+      body_text: item.body_text,
+      parent: parent as IssueData,
+      children: addToChildren(item.children, item),
+    }));
+  }
+
+  return [];
+};

--- a/lib/backend/calculateCompletionRate.ts
+++ b/lib/backend/calculateCompletionRate.ts
@@ -1,13 +1,26 @@
 import { IssueStates } from '../enums';
 
-export function calculateCompletionRate ({ children, state }): number {
-  if (state === IssueStates.CLOSED) return 100;
-  if (!Array.isArray(children)) return 0;
-  const issueStats = Object.create({});
-  issueStats.total = children.length;
-  issueStats.open = children.filter(({state}) => state === IssueStates.OPEN).length;
-  issueStats.closed = children.filter(({state}) => state === IssueStates.CLOSED).length;
-  issueStats.completionRate = Number(Number(issueStats.closed / issueStats.total) * 100 || 0).toFixed(2);
+export interface CalculateCompletionRateOptions {
+  state: IssueStates;
+  children: { state: IssueStates }[];
+}
 
-  return issueStats.completionRate;
+export function calculateCompletionRate ({ children, state }: CalculateCompletionRateOptions): number {
+  children = Array.isArray(children) ? children : [];
+  /**
+   * The total count is all children plus the parent.
+   */
+  const total = children.length + 1;
+  let open = 0;
+  let closed = 0;
+  children.concat([{ state }]).forEach(({state}) => {
+     if (state === IssueStates.OPEN) {
+      open++;
+     } else if (state === IssueStates.CLOSED) {
+      closed++;
+     }
+  });
+  const completionRate = Number((closed / total) * 100 || 0).toFixed(2);
+
+  return Number(completionRate);
 };

--- a/lib/backend/calculateCompletionRate.ts
+++ b/lib/backend/calculateCompletionRate.ts
@@ -1,0 +1,13 @@
+import { IssueStates } from '../enums';
+
+export function calculateCompletionRate ({ children, state }): number {
+  if (state === IssueStates.CLOSED) return 100;
+  if (!Array.isArray(children)) return 0;
+  const issueStats = Object.create({});
+  issueStats.total = children.length;
+  issueStats.open = children.filter(({state}) => state === IssueStates.OPEN).length;
+  issueStats.closed = children.filter(({state}) => state === IssueStates.CLOSED).length;
+  issueStats.completionRate = Number(Number(issueStats.closed / issueStats.total) * 100 || 0).toFixed(2);
+
+  return issueStats.completionRate;
+};

--- a/lib/backend/convertParsedChildToGroupedIssueData.ts
+++ b/lib/backend/convertParsedChildToGroupedIssueData.ts
@@ -1,0 +1,16 @@
+import { paramsFromUrl } from '../paramsFromUrl';
+import { GithubIssueDataWithGroup, ParserGetChildrenResponse } from '../types';
+import { checkForLabel } from './checkForLabel';
+import { getIssue } from './issue';
+
+export async function convertParsedChildToGroupedIssueData(child: ParserGetChildrenResponse): Promise<GithubIssueDataWithGroup> {
+  const urlParams = paramsFromUrl(child.html_url);
+  const issueData = await getIssue(urlParams);
+  checkForLabel(issueData);
+
+  return {
+    ...issueData,
+    labels: issueData?.labels ?? [],
+    group: child.group
+  };
+}

--- a/lib/backend/getGithubIssueDataWithGroupAndChildren.ts
+++ b/lib/backend/getGithubIssueDataWithGroupAndChildren.ts
@@ -1,0 +1,15 @@
+import { getChildren } from '../parser';
+import { GithubIssueDataWithGroup, GithubIssueDataWithGroupAndChildren } from '../types';
+import { resolveChildren } from './resolveChildren';
+import { resolveChildrenWithDepth } from './resolveChildrenWithDepth';
+
+export async function getGithubIssueDataWithGroupAndChildren (issueData: GithubIssueDataWithGroup, usePendingChildren = true): Promise<GithubIssueDataWithGroupAndChildren> {
+  const childrenParsed = getChildren(issueData.body_html);
+
+  return {
+    ...issueData,
+    labels: issueData.labels ?? [],
+    children: usePendingChildren ? [] : await resolveChildrenWithDepth(await resolveChildren(childrenParsed)),
+    pendingChildren: usePendingChildren ? childrenParsed : undefined
+  }
+}

--- a/lib/backend/resolveChildren.ts
+++ b/lib/backend/resolveChildren.ts
@@ -1,0 +1,33 @@
+import { GithubIssueDataWithGroup, ParserGetChildrenResponse } from '../types';
+import { convertParsedChildToGroupedIssueData } from './convertParsedChildToGroupedIssueData';
+import { errorManager } from './errorManager';
+
+export async function resolveChildren (children: ParserGetChildrenResponse[]): Promise<GithubIssueDataWithGroup[]> {
+  if (!Array.isArray(children)) {
+    throw new Error('Children is not an array. Is this a root issue?');
+  }
+
+  try {
+    const validChildren: GithubIssueDataWithGroup[] = []
+
+    for await (const child of children) {
+      try {
+        validChildren.push(await convertParsedChildToGroupedIssueData(child))
+      } catch (err) {
+        errorManager.addError({
+          issue: {
+            html_url: child.html_url,
+            title: child.html_url,
+          },
+          errorTitle: 'Error parsing issue',
+          errorMessage: (err as Error).message,
+          userGuideSection: '#children'
+        })
+      }
+    }
+
+    return validChildren;
+  } catch (reason) {
+    throw new Error(`Error resolving children: ${reason}`);
+  }
+};

--- a/lib/backend/resolveChildren.ts
+++ b/lib/backend/resolveChildren.ts
@@ -26,7 +26,7 @@ export async function resolveChildren (children: ParserGetChildrenResponse[]): P
       }
     }
 
-    return Promise.all(validChildren);
+    return await Promise.all(validChildren);
   } catch (reason) {
     throw new Error(`Error resolving children: ${reason}`);
   }

--- a/lib/backend/resolveChildren.ts
+++ b/lib/backend/resolveChildren.ts
@@ -10,7 +10,7 @@ export async function resolveChildren (children: ParserGetChildrenResponse[]): P
   try {
     const validChildren: Promise<GithubIssueDataWithGroup>[] = []
 
-    for await (const child of children) {
+    for (const child of children) {
       try {
         validChildren.push(convertParsedChildToGroupedIssueData(child))
       } catch (err) {

--- a/lib/backend/resolveChildren.ts
+++ b/lib/backend/resolveChildren.ts
@@ -8,11 +8,11 @@ export async function resolveChildren (children: ParserGetChildrenResponse[]): P
   }
 
   try {
-    const validChildren: GithubIssueDataWithGroup[] = []
+    const validChildren: Promise<GithubIssueDataWithGroup>[] = []
 
     for await (const child of children) {
       try {
-        validChildren.push(await convertParsedChildToGroupedIssueData(child))
+        validChildren.push(convertParsedChildToGroupedIssueData(child))
       } catch (err) {
         errorManager.addError({
           issue: {
@@ -26,7 +26,7 @@ export async function resolveChildren (children: ParserGetChildrenResponse[]): P
       }
     }
 
-    return validChildren;
+    return Promise.all(validChildren);
   } catch (reason) {
     throw new Error(`Error resolving children: ${reason}`);
   }

--- a/lib/backend/resolveChildrenWithDepth.ts
+++ b/lib/backend/resolveChildrenWithDepth.ts
@@ -5,7 +5,7 @@ import { resolveChildren } from './resolveChildren';
 export async function resolveChildrenWithDepth(children: ParserGetChildrenResponse[]): Promise<GithubIssueDataWithGroupAndChildren[]> {
   try {
     const issues = await resolveChildren(children);
-    return await Promise.all(issues.map((issue) => getGithubIssueDataWithGroupAndChildren(issue)));
+    return await Promise.all(issues.map((issue) => getGithubIssueDataWithGroupAndChildren(issue, false)));
   } catch (err) {
     console.error('error:', err);
     return [];

--- a/lib/backend/resolveChildrenWithDepth.ts
+++ b/lib/backend/resolveChildrenWithDepth.ts
@@ -1,0 +1,13 @@
+import { GithubIssueDataWithGroupAndChildren, ParserGetChildrenResponse } from '../types';
+import { getGithubIssueDataWithGroupAndChildren } from './getGithubIssueDataWithGroupAndChildren';
+import { resolveChildren } from './resolveChildren';
+
+export async function resolveChildrenWithDepth(children: ParserGetChildrenResponse[]): Promise<GithubIssueDataWithGroupAndChildren[]> {
+  try {
+    const issues = await resolveChildren(children);
+    return await Promise.all(issues.map((issue) => getGithubIssueDataWithGroupAndChildren(issue)));
+  } catch (err) {
+    console.error('error:', err);
+    return [];
+  }
+};

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -20,7 +20,9 @@ export interface GithubIssueDataWithChildren extends GithubIssueData {
   children: GithubIssueDataWithGroupAndChildren[];
 }
 
-export interface GithubIssueDataWithGroupAndChildren extends GithubIssueDataWithGroup, GithubIssueDataWithChildren {}
+export interface GithubIssueDataWithGroupAndChildren extends GithubIssueDataWithGroup, GithubIssueDataWithChildren {
+  pendingChildren?: ParserGetChildrenResponse[]
+}
 
 export interface IssueData extends GithubIssueDataWithGroupAndChildren {
   children: IssueData[];
@@ -32,6 +34,7 @@ export interface IssueData extends GithubIssueDataWithGroupAndChildren {
 export interface RoadmapApiResponseSuccess {
   data: IssueData;
   errors?: StarMapsIssueErrorsGrouped[];
+  pendingChildren: ParserGetChildrenResponse[];
 }
 export interface RoadmapApiResponseFailure {
   error?: { code: string; message: string };
@@ -101,6 +104,7 @@ export interface ServerSidePropsResult {
     error?: { code: string, message: string } | null;
     mode: RoadmapMode;
     dateGranularity: DateGranularityState;
+    pendingChildren: ParserGetChildrenResponse[]
   }
 }
 

--- a/pages/api/pendingChild.ts
+++ b/pages/api/pendingChild.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { checkForLabel } from '../../lib/backend/checkForLabel';
+import { convertParsedChildToGroupedIssueData } from '../../lib/backend/convertParsedChildToGroupedIssueData';
+import { getGithubIssueDataWithGroupAndChildren } from '../../lib/backend/getGithubIssueDataWithGroupAndChildren';
+import { getIssue } from '../../lib/backend/issue';
+import { GithubIssueDataWithGroupAndChildren } from '../../lib/types';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GithubIssueDataWithGroupAndChildren>
+): Promise<void> {
+  console.log(`API hit: pendingChild`, req.query);
+    const { owner, repo, issue_number, group } = req.query;
+    const githubIssue = await getIssue({ owner, repo, issue_number })
+    checkForLabel(githubIssue);
+    const data = await convertParsedChildToGroupedIssueData({
+      html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
+      group: group as string,
+    })
+    const moreData = await getGithubIssueDataWithGroupAndChildren(data, false)
+    console.log(`data: `, data);
+
+  res.status(200).json({
+    ...moreData
+  });
+
+}

--- a/pages/api/pendingChild.ts
+++ b/pages/api/pendingChild.ts
@@ -10,16 +10,15 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<GithubIssueDataWithGroupAndChildren>
 ): Promise<void> {
-  console.log(`API hit: pendingChild`, req.query);
-    const { owner, repo, issue_number, group } = req.query;
-    const githubIssue = await getIssue({ owner, repo, issue_number })
-    checkForLabel(githubIssue);
-    const data = await convertParsedChildToGroupedIssueData({
-      html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
-      group: group as string,
-    })
-    const moreData = await getGithubIssueDataWithGroupAndChildren(data, false)
-    console.log(`data: `, data);
+  const { owner, repo, issue_number, group } = req.query;
+  const githubIssue = await getIssue({ owner, repo, issue_number })
+  checkForLabel(githubIssue);
+
+  const data = await convertParsedChildToGroupedIssueData({
+    html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
+    group: group as string,
+  })
+  const moreData = await getGithubIssueDataWithGroupAndChildren(data, false)
 
   res.status(200).json({
     ...moreData

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -55,7 +55,6 @@ export async function getServerSideProps(context): Promise<ServerSidePropsResult
   }
 }
 
-let done = false;
 export default function RoadmapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { issueData, error, errors, isLocal, mode, dateGranularity, pendingChildren } = props;
 

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -13,6 +13,8 @@ import { ViewMode } from '../../lib/enums';
 import { setViewMode } from '../../hooks/useViewMode';
 import { DateGranularityState } from '../../lib/enums';
 import { setDateGranularity } from '../../hooks/useDateGranularity';
+import { useAsync } from '../../hooks/useAsync';
+import { paramsFromUrl } from '../../lib/paramsFromUrl';
 
 export async function getServerSideProps(context): Promise<ServerSidePropsResult> {
   const [hostname, owner, repo, issues_placeholder, issue_number] = context.query.slug;
@@ -26,6 +28,7 @@ export async function getServerSideProps(context): Promise<ServerSidePropsResult
     groupBy: filter_group || null,
     mode: mode || 'grid',
     dateGranularity: timeUnit || DateGranularityState.Months,
+    pendingChildren: [],
   };
 
   try {
@@ -33,12 +36,14 @@ export async function getServerSideProps(context): Promise<ServerSidePropsResult
       new URL(`${API_URL}?owner=${owner}&repo=${repo}&issue_number=${issue_number}&filter_group=${filter_group}`),
     );
     const response: RoadmapApiResponse = await res.json();
+    // console.log(`(response as RoadmapApiResponseSuccess)?.pendingChildren: `, (response as RoadmapApiResponseSuccess)?.pendingChildren);
     return {
       props: {
         ...serverSideProps,
         errors: response.errors ?? [],
         error: (response as RoadmapApiResponseFailure).error || null,
         issueData: ((response as RoadmapApiResponseSuccess).data as IssueData) || null,
+        pendingChildren: (response as RoadmapApiResponseSuccess)?.pendingChildren ?? [],
       },
     };
   } catch (err) {
@@ -52,8 +57,59 @@ export async function getServerSideProps(context): Promise<ServerSidePropsResult
   }
 }
 
+let done = false;
 export default function RoadmapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const { issueData, error, errors, isLocal, mode, dateGranularity } = props;
+  const { issueData, error, errors, isLocal, mode, dateGranularity, pendingChildren } = props;
+  const pendingChild = pendingChildren[0]
+  const {execute, status, value, error: asyncError} = useAsync(async () => {
+  //   for await (const pendingChild of pendingChildren) {
+    if (done) {
+      return;
+    }
+      done = true
+      console.log(`pendingChild: `, pendingChild);
+      const { issue_number, owner, repo } = paramsFromUrl(pendingChild.html_url)
+      const params = new URLSearchParams()
+      params.append('issue_number', issue_number);
+      params.append('repo', repo);
+      params.append('owner', owner);
+      params.append('group', pendingChild.group);
+      const url = new URL(`${window.location.origin}/api/pendingChild?${params}`)
+      console.log(`url: `, url);
+      try {
+        const res = await fetch(url);
+        const response: RoadmapApiResponse = await res.json();
+        console.log(`response: `, response);
+      } catch (err) {
+        console.error('error getting pending child', err);
+        // break;
+        throw err
+      }
+
+  //   }
+  }, false);
+  // console.log(`asyncError: `, asyncError);
+  // console.log(`value: `, value);
+  // console.log(`status: `, status);
+  // console.log(`execute: `, execute);
+
+  useEffect(() => {
+    switch(status) {
+      case 'idle':
+        execute();
+        break;
+      case 'error':
+        console.log('error', asyncError);
+        break;
+      case 'pending':
+        break;
+      case 'success':
+        console.log('success', value);
+
+        break;
+    }
+  }, [status, value, execute, asyncError])
+
 
   useEffect(() => {
     setDateGranularity(dateGranularity);

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -13,8 +13,6 @@ import { ViewMode } from '../../lib/enums';
 import { setViewMode } from '../../hooks/useViewMode';
 import { DateGranularityState } from '../../lib/enums';
 import { setDateGranularity } from '../../hooks/useDateGranularity';
-import { useAsync } from '../../hooks/useAsync';
-import { paramsFromUrl } from '../../lib/paramsFromUrl';
 
 export async function getServerSideProps(context): Promise<ServerSidePropsResult> {
   const [hostname, owner, repo, issues_placeholder, issue_number] = context.query.slug;
@@ -36,7 +34,7 @@ export async function getServerSideProps(context): Promise<ServerSidePropsResult
       new URL(`${API_URL}?owner=${owner}&repo=${repo}&issue_number=${issue_number}&filter_group=${filter_group}`),
     );
     const response: RoadmapApiResponse = await res.json();
-    // console.log(`(response as RoadmapApiResponseSuccess)?.pendingChildren: `, (response as RoadmapApiResponseSuccess)?.pendingChildren);
+
     return {
       props: {
         ...serverSideProps,
@@ -60,56 +58,6 @@ export async function getServerSideProps(context): Promise<ServerSidePropsResult
 let done = false;
 export default function RoadmapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { issueData, error, errors, isLocal, mode, dateGranularity, pendingChildren } = props;
-  const pendingChild = pendingChildren[0]
-  const {execute, status, value, error: asyncError} = useAsync(async () => {
-  //   for await (const pendingChild of pendingChildren) {
-    if (done) {
-      return;
-    }
-      done = true
-      console.log(`pendingChild: `, pendingChild);
-      const { issue_number, owner, repo } = paramsFromUrl(pendingChild.html_url)
-      const params = new URLSearchParams()
-      params.append('issue_number', issue_number);
-      params.append('repo', repo);
-      params.append('owner', owner);
-      params.append('group', pendingChild.group);
-      const url = new URL(`${window.location.origin}/api/pendingChild?${params}`)
-      console.log(`url: `, url);
-      try {
-        const res = await fetch(url);
-        const response: RoadmapApiResponse = await res.json();
-        console.log(`response: `, response);
-      } catch (err) {
-        console.error('error getting pending child', err);
-        // break;
-        throw err
-      }
-
-  //   }
-  }, false);
-  // console.log(`asyncError: `, asyncError);
-  // console.log(`value: `, value);
-  // console.log(`status: `, status);
-  // console.log(`execute: `, execute);
-
-  useEffect(() => {
-    switch(status) {
-      case 'idle':
-        execute();
-        break;
-      case 'error':
-        console.log('error', asyncError);
-        break;
-      case 'pending':
-        break;
-      case 'success':
-        console.log('success', value);
-
-        break;
-    }
-  }, [status, value, execute, asyncError])
-
 
   useEffect(() => {
     setDateGranularity(dateGranularity);

--- a/tests/unit/backend/calculateCompletionRate.test.ts
+++ b/tests/unit/backend/calculateCompletionRate.test.ts
@@ -13,18 +13,18 @@ describe('calculateCompletionRate', function() {
     it('with 1 closed child to 100', () => {
       expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}], state: IssueStates.CLOSED})).toEqual(100);
     });
-    it('without valid children to 0', () => {
+    it('without valid children to 100', () => {
       expect(calculateCompletionRate({children: null as unknown as {state: IssueStates}[], state: IssueStates.CLOSED})).toEqual(100);
     });
 
     describe('multiple children', () => {
-      it('with 2 open children', () => {
+      it('with 2 open children to 33.33', () => {
         expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.OPEN}], state: IssueStates.CLOSED})).toEqual(33.33);
       });
-      it('with 1 open child and 1 closed child', () => {
+      it('with 1 open child and 1 closed child to 66.67', () => {
         expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.CLOSED}], state: IssueStates.CLOSED})).toEqual(66.67);
       });
-      it('with 2 closed children', () => {
+      it('with 2 closed children to 100', () => {
         expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}, {state: IssueStates.CLOSED}], state: IssueStates.CLOSED})).toEqual(100);
       });
     });
@@ -34,7 +34,7 @@ describe('calculateCompletionRate', function() {
     it('with no children to 0', () => {
       expect(calculateCompletionRate({children: [], state: IssueStates.OPEN})).toEqual(0);
     });
-    it('with 1 open child to 50', () => {
+    it('with 1 open child to 0', () => {
       expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}], state: IssueStates.OPEN})).toEqual(0);
     });
     it('with 1 closed child to 50', () => {
@@ -45,13 +45,13 @@ describe('calculateCompletionRate', function() {
     });
 
     describe('multiple children', () => {
-      it('with 2 open children', () => {
+      it('with 2 open children to 0', () => {
         expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.OPEN}], state: IssueStates.OPEN})).toEqual(0);
       });
-      it('with 1 open child and 1 closed child', () => {
+      it('with 1 open child and 1 closed child to 33.33', () => {
         expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(33.33);
       });
-      it('with 2 closed children', () => {
+      it('with 2 closed children to 66.67', () => {
         expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}, {state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(66.67);
       });
     });

--- a/tests/unit/backend/calculateCompletionRate.test.ts
+++ b/tests/unit/backend/calculateCompletionRate.test.ts
@@ -1,0 +1,18 @@
+import { calculateCompletionRate } from '../../../lib/backend/calculateCompletionRate'
+import { IssueStates } from '../../../lib/enums';
+
+describe('calculateCompletionRate', function() {
+  it('converts a closed issue to 100', () => {
+    expect(calculateCompletionRate({children: [], state: IssueStates.CLOSED})).toEqual(100);
+  })
+  it('converts an open issue without valid children to 0', () => {
+    expect(calculateCompletionRate({children: null as unknown as {state: IssueStates}[], state: IssueStates.OPEN})).toEqual(0);
+  })
+
+  it('converts an open issue with 1 closed child to 50', () => {
+    expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(50);
+  })
+  it('converts an open issue with 1 closed child to 50', () => {
+    expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(50);
+  })
+})

--- a/tests/unit/backend/calculateCompletionRate.test.ts
+++ b/tests/unit/backend/calculateCompletionRate.test.ts
@@ -2,17 +2,58 @@ import { calculateCompletionRate } from '../../../lib/backend/calculateCompletio
 import { IssueStates } from '../../../lib/enums';
 
 describe('calculateCompletionRate', function() {
-  it('converts a closed issue to 100', () => {
-    expect(calculateCompletionRate({children: [], state: IssueStates.CLOSED})).toEqual(100);
-  })
-  it('converts an open issue without valid children to 0', () => {
-    expect(calculateCompletionRate({children: null as unknown as {state: IssueStates}[], state: IssueStates.OPEN})).toEqual(0);
-  })
 
-  it('converts an open issue with 1 closed child to 50', () => {
-    expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(50);
-  })
-  it('converts an open issue with 1 closed child to 50', () => {
-    expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(50);
+  describe('parent issue closed', () => {
+    it('with no children to 100', () => {
+      expect(calculateCompletionRate({children: [], state: IssueStates.CLOSED})).toEqual(100);
+    });
+    it('with 1 open child to 50', () => {
+      expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}], state: IssueStates.CLOSED})).toEqual(50);
+    });
+    it('with 1 closed child to 100', () => {
+      expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}], state: IssueStates.CLOSED})).toEqual(100);
+    });
+    it('without valid children to 0', () => {
+      expect(calculateCompletionRate({children: null as unknown as {state: IssueStates}[], state: IssueStates.CLOSED})).toEqual(100);
+    });
+
+    describe('multiple children', () => {
+      it('with 2 open children', () => {
+        expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.OPEN}], state: IssueStates.CLOSED})).toEqual(33.33);
+      });
+      it('with 1 open child and 1 closed child', () => {
+        expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.CLOSED}], state: IssueStates.CLOSED})).toEqual(66.67);
+      });
+      it('with 2 closed children', () => {
+        expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}, {state: IssueStates.CLOSED}], state: IssueStates.CLOSED})).toEqual(100);
+      });
+    });
+  });
+
+  describe('parent issue open', () => {
+    it('with no children to 0', () => {
+      expect(calculateCompletionRate({children: [], state: IssueStates.OPEN})).toEqual(0);
+    });
+    it('with 1 open child to 50', () => {
+      expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}], state: IssueStates.OPEN})).toEqual(0);
+    });
+    it('with 1 closed child to 50', () => {
+      expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(50);
+    });
+    it('without valid children to 0', () => {
+      expect(calculateCompletionRate({children: null as unknown as {state: IssueStates}[], state: IssueStates.OPEN})).toEqual(0);
+    });
+
+    describe('multiple children', () => {
+      it('with 2 open children', () => {
+        expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.OPEN}], state: IssueStates.OPEN})).toEqual(0);
+      });
+      it('with 1 open child and 1 closed child', () => {
+        expect(calculateCompletionRate({children: [{state: IssueStates.OPEN}, {state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(33.33);
+      });
+      it('with 2 closed children', () => {
+        expect(calculateCompletionRate({children: [{state: IssueStates.CLOSED}, {state: IssueStates.CLOSED}], state: IssueStates.OPEN})).toEqual(66.67);
+      });
+    });
   })
 })


### PR DESCRIPTION
- fix: better error handling for children
- feat: start working on async loading of children
- chore: clean-up code for breaking up roadmap.ts

replaces https://github.com/pln-planning-tools/StarMaps/pull/169
precursor to https://github.com/pln-planning-tools/StarMaps/pull/170
