### PR TITLE
fix: styling and layout for github icons

### DIFF
--- a/components/icons/svgr/SvgGitHubLogoWithTooltip.tsx
+++ b/components/icons/svgr/SvgGitHubLogoWithTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, Flex } from '@chakra-ui/react';
+import { Tooltip } from '@chakra-ui/react';
 import React from 'react';
 
 import SvgGitHubLogo from './SvgGitHubLogo';

--- a/components/icons/svgr/SvgGitHubLogoWithTooltip.tsx
+++ b/components/icons/svgr/SvgGitHubLogoWithTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from '@chakra-ui/react';
+import { Tooltip, Flex } from '@chakra-ui/react';
 import React from 'react';
 
 import SvgGitHubLogo from './SvgGitHubLogo';

--- a/components/roadmap-grid/Roadmap.module.css
+++ b/components/roadmap-grid/Roadmap.module.css
@@ -112,11 +112,13 @@
 }
 
 .milestoneTitleWrapper {
-  padding-bottom: 25px;
-  overflow: hidden;
   text-overflow: ellipsis;
   margin-top: 0.2rem;
-  max-width: 20rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
 }
 
 .milestoneTitle {
@@ -131,6 +133,7 @@ a.milestoneTitle {
 .milestoneDate {
   font-size: 13px;
   justify-self: right;
+  padding-top: 25px;
   /* position: relative;
   bottom: 1rempx; */
 }

--- a/components/roadmap-grid/grid-row.tsx
+++ b/components/roadmap-grid/grid-row.tsx
@@ -66,13 +66,15 @@ export function GridRow({
       className={`${styles.item} ${styles.issueItem} ${clickable && styles.wrapperLink}`}
 
     >
-      <Flex direction="row" position="relative">
-        <Flex direction="column">
+      <Flex direction={{base:"column", md:"column", lg:"row"}} justify="space-between" position="relative">
+        <Flex direction="column" maxW={{base: "100%", sm: "100%", md:"100%", lg:"85%"}}>
           <Text as="b" className={styles.milestoneTitleWrapper}>{milestone.title}</Text>
-          <div className={styles.milestoneDate}>{milestone.due_date}</div>
+          <p className={styles.milestoneDate}>{milestone.due_date}</p>
         </Flex>
-        <Spacer />
-        <SvgGitHubLogoWithTooltip githuburl={milestone.html_url}/>
+        <Flex m={{base: "0", sm: "8px 0", md: "8px 0", lg: "0"}}>
+          <SvgGitHubLogoWithTooltip githuburl={milestone.html_url}/>
+        </Flex>
+
       </Flex>
     </div>
   );


### PR DESCRIPTION
Closes Issues #150 

-  Updated styling and minor layout changes to grid-row
-  Smaller screens will change to a stacked view within the card (as discussed with @juliaxbow )
-  Added back ellipsis as screen sizes scale down and text gets cutoff