### PR TITLE
feat: make api/roadmap call from client

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 IS_LOCAL=true
+VERCEL_URL="localhost:3000"
 NEXT_PUBLIC_VERCEL_URL="localhost:3000"
 URL_PROTOCOL="http"

--- a/components/RoadmapForm.tsx
+++ b/components/RoadmapForm.tsx
@@ -4,7 +4,7 @@ import { SearchIcon } from '@chakra-ui/icons'
 import { match } from 'path-to-regexp';
 import { useEffect, useState } from 'react';
 
-import { setIsLoading, useIsLoading } from '../hooks/useIsLoading';
+import { useGlobalLoadingState } from '../hooks/useGlobalLoadingState';
 import styles from './RoadmapForm.module.css'
 import theme from './theme/constants'
 import { setCurrentIssueUrl, useCurrentIssueUrl } from '../hooks/useCurrentIssueUrl';
@@ -22,7 +22,7 @@ const slugsFromUrl: any = (url) => {
 
 export function RoadmapForm() {
   const router = useRouter();
-  const isLoading = useIsLoading();
+  const globalLoadingState = useGlobalLoadingState();
   const currentIssueUrl = useCurrentIssueUrl();
   const [issueUrl, setIssueUrl] = useState<string | null>();
   const [error, setError] = useState<Error | null>(null);
@@ -56,11 +56,12 @@ export function RoadmapForm() {
               throw new Error('Already viewing this issue');
             }
             await router.push(`/roadmap/github.com/${owner}/${repo}/issues/${issue_number}`);
-            setIsLoading(false);
+            globalLoadingState.stop();
           }
         } catch (err) {
           setError(err as Error);
-          setIsLoading(false);
+          globalLoadingState.stop();
+
         }
       }
     };
@@ -69,7 +70,7 @@ export function RoadmapForm() {
 
   const formSubmit = (e) => {
     e.preventDefault();
-    setIsLoading(true);
+    globalLoadingState.start();
     setError(null);
 
     try {
@@ -80,16 +81,16 @@ export function RoadmapForm() {
       setIssueUrl(newUrl.toString());
     } catch (err) {
       setError(err as Error);
-      setIsLoading(false);
+      globalLoadingState.stop();
     }
   }
 
   let inputRightElement = (
-    <Button type="submit" isLoading={isLoading} className={styles.formSubmitButton} border="1px solid #8D8D8D" borderRadius="4px"  bg="rgba(141, 141, 141, 0.3)" onClick={formSubmit}>
+    <Button type="submit" isLoading={globalLoadingState.get()} className={styles.formSubmitButton} border="1px solid #8D8D8D" borderRadius="4px"  bg="rgba(141, 141, 141, 0.3)" onClick={formSubmit}>
       <Text p="6px 10px" color="white">⏎</Text>
     </Button>
   )
-  if (isLoading) {
+  if (globalLoadingState.get()) {
     inputRightElement = <Spinner />
   }
   const onChangeHandler = (e) => {

--- a/components/RoadmapForm.tsx
+++ b/components/RoadmapForm.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 import { Button, FormControl, FormErrorMessage, Input, InputGroup, InputLeftElement, InputRightElement, Spinner, Text } from '@chakra-ui/react';
 import { SearchIcon } from '@chakra-ui/icons'
-import { match } from 'path-to-regexp';
 import { useEffect, useState } from 'react';
 
 import { useGlobalLoadingState } from '../hooks/useGlobalLoadingState';
@@ -12,14 +11,6 @@ import { isEmpty } from 'lodash';
 import { paramsFromUrl } from '../lib/paramsFromUrl';
 import { getValidUrlFromInput } from '../lib/getValidUrlFromInput';
 
-const slugsFromUrl: any = (url) => {
-  const matchResult = match('/:owner/:repo/issues/:issue_number(\\d+)', {
-    decode: decodeURIComponent,
-  })(url);
-
-  return matchResult;
-};
-
 export function RoadmapForm() {
   const router = useRouter();
   const globalLoadingState = useGlobalLoadingState();
@@ -27,6 +18,7 @@ export function RoadmapForm() {
   const [issueUrl, setIssueUrl] = useState<string | null>();
   const [error, setError] = useState<Error | null>(null);
   const [isInputBlanked, setIsInputBlanked] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState(globalLoadingState.get());
 
   useEffect(() => {
     if (!isInputBlanked && isEmpty(currentIssueUrl) && window.location.pathname.length > 1) {
@@ -56,12 +48,11 @@ export function RoadmapForm() {
               throw new Error('Already viewing this issue');
             }
             await router.push(`/roadmap/github.com/${owner}/${repo}/issues/${issue_number}`);
-            globalLoadingState.stop();
+            setIsLoading(false);
           }
         } catch (err) {
           setError(err as Error);
-          globalLoadingState.stop();
-
+          setIsLoading(false);
         }
       }
     };
@@ -70,7 +61,7 @@ export function RoadmapForm() {
 
   const formSubmit = (e) => {
     e.preventDefault();
-    globalLoadingState.start();
+    setIsLoading(true);
     setError(null);
 
     try {
@@ -81,7 +72,7 @@ export function RoadmapForm() {
       setIssueUrl(newUrl.toString());
     } catch (err) {
       setError(err as Error);
-      globalLoadingState.stop();
+      setIsLoading(false);
     }
   }
 

--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -19,6 +19,7 @@ import NumSlider from '../inputs/NumSlider';
 import { dayjs } from '../../lib/client/dayjs';
 import { DEFAULT_TICK_COUNT } from '../../config/constants';
 import { globalTimeScaler } from '../../lib/client/TimeScaler';
+import React from 'react';
 
 export function RoadmapDetailed({
   issueData
@@ -161,14 +162,14 @@ export function RoadmapDetailed({
         <Grid ticksLength={numGridCols} scroll={true}  renderTodayLine={true} >
           {_.reverse(Array.from(_.sortBy(issuesGrouped, ['groupName']))).map((group, index) => {
             return (
-              <>
-                <GroupHeader group={group} /><GroupWrapper key={index}>
+              <React.Fragment key={`Fragment-${index}`} >
+                <GroupHeader group={group} key={`GroupHeader-${index}`}/><GroupWrapper key={`GroupWrapper-${index}`}>
                   {!!group.items &&
                     _.sortBy(group.items, ['title']).map((item, index) => {
                       return <GridRow key={index} timeScaler={globalTimeScaler} milestone={item} index={index} timelineTicks={ticks} numGridCols={numGridCols} numHeaderItems={numHeaderTicks} />;
                     })}
                 </GroupWrapper>
-              </>
+              </React.Fragment>
             );
           })}
         </Grid>

--- a/components/roadmap/NewRoadmap.tsx
+++ b/components/roadmap/NewRoadmap.tsx
@@ -3,7 +3,7 @@ import { Box, Center, Spinner } from '@chakra-ui/react';
 import { scaleTime } from 'd3';
 import { useEffect, useRef, useState } from 'react';
 
-import { useIsLoading } from '../../hooks/useIsLoading';
+import { useGlobalLoadingState } from '../../hooks/useGlobalLoadingState';
 import { useMaxHeight, setMaxHeight } from '../../hooks/useMaxHeight';
 import { dayjs } from '../../lib/client/dayjs';
 import { IssueData } from '../../lib/types';
@@ -35,13 +35,13 @@ function NewRoadmap({ issueData, isLocal }: { issueData: IssueData; isLocal: boo
   const margin = { top: 0, right: 0, bottom: 20, left: 0 };
   const width = maxW - margin.left - margin.right;
   const height = maxH - margin.top - margin.bottom;
-  const isLoading = useIsLoading();
+  const globalLoadingState = useGlobalLoadingState();
 
   const scaleX = scaleTime()
     .domain([earliestEta.subtract(minMaxDiff / 4, 'days').toDate(), latestEta.add(minMaxDiff / 6, 'days').toDate()])
     .range([0, width]);
 
-  if (isLoading) {
+  if (globalLoadingState.get()) {
     return (
       <Center h={maxH} w={maxW}>
         <Spinner size='xl' />

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,6 +1,5 @@
 export const BASE_PROTOCOL = (!!process.env.IS_LOCAL && 'http') || 'https';
 export const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL;
-export const API_URL = new URL(`${BASE_PROTOCOL}://${BASE_URL}/api/roadmap`);
 export const DEFAULT_TICK_COUNT = 5;
 export const OFFSET_MAX_MONTHS = 3;
 export const OFFSET_MIN_MONTHS = 2;

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,15 +1,7 @@
-const BASE_PROTOCOL = (!!process.env.IS_LOCAL && 'http') || 'https';
-const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL;
-const API_URL = new URL(`${BASE_PROTOCOL}://${BASE_URL}/api/roadmap`);
-const DEFAULT_TICK_COUNT = 5;
-const OFFSET_MAX_MONTHS = 3;
-const OFFSET_MIN_MONTHS = 2;
-const TEN_DAYS_IN_SECONDS = 864000;
-
-export {
-  API_URL,
-  DEFAULT_TICK_COUNT,
-  OFFSET_MAX_MONTHS,
-  OFFSET_MIN_MONTHS,
-  TEN_DAYS_IN_SECONDS
-}
+export const BASE_PROTOCOL = (!!process.env.IS_LOCAL && 'http') || 'https';
+export const BASE_URL = process.env.NEXT_PUBLIC_VERCEL_URL;
+export const API_URL = new URL(`${BASE_PROTOCOL}://${BASE_URL}/api/roadmap`);
+export const DEFAULT_TICK_COUNT = 5;
+export const OFFSET_MAX_MONTHS = 3;
+export const OFFSET_MIN_MONTHS = 2;
+export const TEN_DAYS_IN_SECONDS = 864000;

--- a/hooks/useGlobalLoadingState.ts
+++ b/hooks/useGlobalLoadingState.ts
@@ -1,0 +1,14 @@
+import { hookstate, State, useHookstate } from '@hookstate/core';
+
+const globalLoadingState = hookstate(false);
+const wrapState = (s: State<boolean>) => ({
+  get: () => s.value,
+  toggle: () => s.set(p => !p),
+  start: () => s.set(true),
+  stop: () => s.set(false),
+})
+
+// The following 2 functions can be exported now:
+export const accessGlobalLoadingState = () => wrapState(globalLoadingState)
+export const useGlobalLoadingState = () => wrapState(useHookstate(globalLoadingState))
+

--- a/hooks/useIsLoading.ts
+++ b/hooks/useIsLoading.ts
@@ -1,7 +1,0 @@
-import { useState } from 'react';
-
-import useSharedHook from '../lib/client/createSharedHook';
-
-const [useIsLoading, setIsLoading] = useSharedHook(useState, false);
-
-export { useIsLoading, setIsLoading };

--- a/lib/backend/errorManager.ts
+++ b/lib/backend/errorManager.ts
@@ -1,10 +1,7 @@
 import {
   GithubIssueData,
-  StarMapsError,
-  StarMapsIssueError,
-  StarMapsIssueErrorsGrouped
-} from '../types';
-import { groupBy } from 'lodash';
+  StarMapsError} from '../types';
+import { groupStarMapsErrors } from '../groupStarMapsErrors';
 
 export class ErrorManager {
   errors: StarMapsError[];
@@ -12,29 +9,7 @@ export class ErrorManager {
     this.errors = [];
   }
 
-  private processStarMapsErrors(): StarMapsIssueErrorsGrouped[] {
-    const groupedErrors = groupBy(this.errors, 'issueUrl');
-    const processedErrors: StarMapsIssueErrorsGrouped[] = [];
-    for (const [url, errorsForUrl] of Object.entries(groupedErrors)) {
-      const urlErrors: StarMapsIssueError[] = []
-      errorsForUrl.forEach((starMapError) => {
-        urlErrors.push({
-          // errors:
-          userGuideUrl: starMapError.userGuideUrl,
-          title: starMapError.title,
-          message: starMapError.message,
-        });
 
-      });
-      processedErrors.push({
-        issueUrl: url,
-        issueTitle: errorsForUrl[0].issueTitle,
-        errors: urlErrors,
-      });
-    }
-
-    return processedErrors;
-  }
 
   addError({
     issue,
@@ -58,7 +33,7 @@ export class ErrorManager {
   }
 
   flushErrors() {
-    const errors = this.processStarMapsErrors();
+    const errors = groupStarMapsErrors(this.errors);
     this.clearErrors();
     return errors;
   }

--- a/lib/backend/getGithubIssueDataWithGroupAndChildren.ts
+++ b/lib/backend/getGithubIssueDataWithGroupAndChildren.ts
@@ -1,15 +1,23 @@
 import { getChildren } from '../parser';
-import { GithubIssueDataWithGroup, GithubIssueDataWithGroupAndChildren } from '../types';
+import { GithubIssueDataWithGroup, GithubIssueDataWithGroupAndChildren, ParserGetChildrenResponse, PendingChildren } from '../types';
 import { resolveChildren } from './resolveChildren';
 import { resolveChildrenWithDepth } from './resolveChildrenWithDepth';
 
-export async function getGithubIssueDataWithGroupAndChildren (issueData: GithubIssueDataWithGroup, usePendingChildren = true): Promise<GithubIssueDataWithGroupAndChildren> {
-  const childrenParsed = getChildren(issueData.body_html);
+export async function getGithubIssueDataWithGroupAndChildren (issueData: GithubIssueDataWithGroup, usePendingChildren = false): Promise<GithubIssueDataWithGroupAndChildren> {
+  const childrenParsed: ParserGetChildrenResponse[] = getChildren(issueData.body_html);
+  let pendingChildren: PendingChildren[] | undefined = undefined;
+  let children: GithubIssueDataWithGroupAndChildren[] = [];
+
+  if (usePendingChildren) {
+    pendingChildren = childrenParsed.map(({html_url}) => ({html_url, group: issueData.title, parentHtmlUrl: issueData.html_url}))
+  } else {
+    children = await resolveChildrenWithDepth(await resolveChildren(childrenParsed))
+  }
 
   return {
     ...issueData,
     labels: issueData.labels ?? [],
-    children: usePendingChildren ? [] : await resolveChildrenWithDepth(await resolveChildren(childrenParsed)),
-    pendingChildren: usePendingChildren ? childrenParsed : undefined
+    children,
+    pendingChildren,
   }
 }

--- a/lib/groupStarMapsErrors.ts
+++ b/lib/groupStarMapsErrors.ts
@@ -1,0 +1,27 @@
+import { groupBy, uniqBy } from 'lodash';
+
+import { StarMapsError, StarMapsIssueError, StarMapsIssueErrorsGrouped } from './types';
+
+export function groupStarMapsErrors(errors: StarMapsError[]): StarMapsIssueErrorsGrouped[] {
+    const groupedErrors = groupBy(uniqBy(errors, (error) => `${error.issueUrl}${error.message}`), 'issueUrl');
+    const processedErrors: StarMapsIssueErrorsGrouped[] = [];
+    for (const [url, errorsForUrl] of Object.entries(groupedErrors)) {
+      const urlErrors: StarMapsIssueError[] = []
+      errorsForUrl.forEach((starMapError) => {
+        urlErrors.push({
+          // errors:
+          userGuideUrl: starMapError.userGuideUrl,
+          title: starMapError.title,
+          message: starMapError.message,
+        });
+
+      });
+      processedErrors.push({
+        issueUrl: url,
+        issueTitle: errorsForUrl[0].issueTitle,
+        errors: urlErrors,
+      });
+    }
+
+    return processedErrors;
+  }

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -30,7 +30,7 @@ export interface IssueData extends GithubIssueDataWithGroupAndChildren {
   children: IssueData[];
   completion_rate: number;
   due_date: string;
-  parent?: ParentIssueData;
+  parent: ParentIssueData;
 }
 
 export interface RoadmapApiResponseSuccess {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -21,7 +21,7 @@ export interface GithubIssueDataWithChildren extends GithubIssueData {
 }
 
 export interface GithubIssueDataWithGroupAndChildren extends GithubIssueDataWithGroup, GithubIssueDataWithChildren {
-  pendingChildren?: ParserGetChildrenResponse[]
+  pendingChildren?: PendingChildren[]
 }
 
 export interface IssueData extends GithubIssueDataWithGroupAndChildren {
@@ -34,7 +34,7 @@ export interface IssueData extends GithubIssueDataWithGroupAndChildren {
 export interface RoadmapApiResponseSuccess {
   data: IssueData;
   errors?: StarMapsIssueErrorsGrouped[];
-  pendingChildren: ParserGetChildrenResponse[];
+  pendingChildren: PendingChildren[];
 }
 export interface RoadmapApiResponseFailure {
   error?: { code: string; message: string };
@@ -46,6 +46,9 @@ export type RoadmapApiResponse = RoadmapApiResponseSuccess | RoadmapApiResponseF
 export interface ParserGetChildrenResponse {
   html_url: string;
   group: string;
+}
+export interface PendingChildren extends ParserGetChildrenResponse {
+  parentHtmlUrl: string;
 }
 
 interface RoadmapProps {}

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -24,11 +24,13 @@ export interface GithubIssueDataWithGroupAndChildren extends GithubIssueDataWith
   pendingChildren?: PendingChildren[]
 }
 
+export type ParentIssueData = IssueData;
+
 export interface IssueData extends GithubIssueDataWithGroupAndChildren {
   children: IssueData[];
   completion_rate: number;
   due_date: string;
-  parent: IssueData;
+  parent?: ParentIssueData;
 }
 
 export interface RoadmapApiResponseSuccess {
@@ -94,20 +96,20 @@ export interface StarMapsIssueErrorsGrouped {
 }
 
 
-export interface ServerSidePropsResult {
+export interface RoadmapServerSidePropsResult {
   props: {
-    issueData: IssueData | null,
-    errors: StarMapsIssueErrorsGrouped[],
     error: { code: string; message: string } | null,
-    isLocal: boolean,
-    /**
-     * Used via the filter_group query parameter to filter the roadmap by a specific group.
-     */
+    owner: string;
+    repo: string;
+    issue_number: string;
+    isLocal: boolean;
+
     groupBy: string | null,
     error?: { code: string, message: string } | null;
     mode: RoadmapMode;
     dateGranularity: DateGranularityState;
-    pendingChildren: ParserGetChildrenResponse[]
+    pendingChildren?: ParserGetChildrenResponse[];
+    baseUrl: string;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@chakra-ui/react": "^2.3.6",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@hookstate/core": "^4.0.0-rc21",
     "@octokit/core": "^4.0.0",
     "@octokit/graphql-schema": "^12.9.1",
     "@octokit/plugin-retry": "^3.0.9",

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -66,7 +66,7 @@ export default function RoadmapPage(props: InferGetServerSidePropsType<typeof ge
 
     fetchRoadMapResponse();
 
-  }, []);
+  }, [issue_number, repo, owner]);
 
   useEffect(() => {
     setDateGranularity(dateGranularity);

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -46,7 +46,7 @@ export default function RoadmapPage(props: InferGetServerSidePropsType<typeof ge
     if (globalLoadingState.get()) return;
     const fetchRoadMapResponse = async () => {
       globalLoadingState.start();
-      const roadmapApiUrl = `${baseUrl}/api/roadmap?owner=${owner}&repo=${repo}&issue_number=${issue_number}`
+      const roadmapApiUrl = `${window.location.origin}/api/roadmap?owner=${owner}&repo=${repo}&issue_number=${issue_number}`
       try {
         const apiResult = await fetch(new URL(roadmapApiUrl))
         const roadmapResponse: RoadmapApiResponse = await apiResult.json();

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -29,7 +29,7 @@ export async function getServerSideProps(context): Promise<RoadmapServerSideProp
       groupBy: filter_group || null,
       mode: mode || 'grid',
       dateGranularity: timeUnit || DateGranularityState.Months,
-      baseUrl: `${BASE_PROTOCOL}://${BASE_URL}`,
+      baseUrl: `${BASE_PROTOCOL}://${process.env.VERCEL_URL}`,
     }
   }
 }
@@ -48,7 +48,7 @@ export default function RoadmapPage(props: InferGetServerSidePropsType<typeof ge
       globalLoadingState.start();
       const roadmapApiUrl = `${baseUrl}/api/roadmap?owner=${owner}&repo=${repo}&issue_number=${issue_number}`
       try {
-        const apiResult = await fetch(new URL(roadmapApiUrl), {mode: 'no-cors'})
+        const apiResult = await fetch(new URL(roadmapApiUrl))
         const roadmapResponse: RoadmapApiResponse = await apiResult.json();
 
         const roadmapResponseSuccess = roadmapResponse as RoadmapApiResponseSuccess;

--- a/pages/roadmap/[...slug].tsx
+++ b/pages/roadmap/[...slug].tsx
@@ -48,7 +48,7 @@ export default function RoadmapPage(props: InferGetServerSidePropsType<typeof ge
       globalLoadingState.start();
       const roadmapApiUrl = `${baseUrl}/api/roadmap?owner=${owner}&repo=${repo}&issue_number=${issue_number}`
       try {
-        const apiResult = await fetch(new URL(roadmapApiUrl))
+        const apiResult = await fetch(new URL(roadmapApiUrl), {mode: 'no-cors'})
         const roadmapResponse: RoadmapApiResponse = await apiResult.json();
 
         const roadmapResponseSuccess = roadmapResponse as RoadmapApiResponseSuccess;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,6 +1350,11 @@
   resolved "https://registry.yarnpkg.com/@github/browserslist-config/-/browserslist-config-1.0.0.tgz#952fe6da3e6b8ed6a368f3a1a08a9d2ef84e8d04"
   integrity sha512-gIhjdJp/c2beaIWWIlsXdqXVRUz3r2BxBCpfz/F3JXHvSAQ1paMYjLH+maEATtENg+k5eLV7gA+9yPp762ieuw==
 
+"@hookstate/core@^4.0.0-rc21":
+  version "4.0.0-rc21"
+  resolved "https://registry.yarnpkg.com/@hookstate/core/-/core-4.0.0-rc21.tgz#5c7c8e1ec02d7a2eea148edf88b9c8aa3baf0fa8"
+  integrity sha512-aAiF537i9a54OlWzA/EtOa1l4bJMmpmJ4Fb/ZV8R30xD6jGMCGbCxHcb6SWIqO92T/w8dFXyl5XQbQ8reFpQrA==
+
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz#38aec044c6c828f6ed51d5d7ae3d9b9faf6dbb0f"


### PR DESCRIPTION

## Summary of this PR:

1. Ensures initial page request of /roadmap/github.com/ipfs/roadmap/issues/102#detail returns without needing to wait on querying all the issues
2. Loads the issues (via /api/roadmap) from the RoadMap page, client side.
3. gets us closer to fully loading nested children from the client (see branch `fix/bacalhau-1151-with-async-children`)
4. significantly improves first load time and isolates backend request time which limits risks that vercel limits will bite us.

### commits
-   feat: update global isLoading
-   fix: react key error
-   chore: update errorManager
-   chore: update getGithubIssueDataWithGroupAndChildren
-   feat: load roadmap after initial server response
-   fix: types

This issue continues along with a number of other issues to resolve #158:

-   builds further on #179
-   fixes #180
-   partially fixes #103

### Prior to this change

#### browser network size and timing
![image](https://user-images.githubusercontent.com/1173416/203708452-814360c2-2797-4efc-8f4a-d767b8e30f9e.png)

![image](https://user-images.githubusercontent.com/1173416/203708504-396f431b-3251-40ca-996a-c53a5298c5a9.png)

### After this change (from localhost)

#### browser network size

![image](https://user-images.githubusercontent.com/1173416/203711703-d2715518-372d-4942-ba36-1716ffb4588b.png)

##### Initial page load timing

![image](https://user-images.githubusercontent.com/1173416/203711891-b9ddf9b2-52a8-4b98-9021-5579f5b0d213.png)

##### Roadmap API timing

![image](https://user-images.githubusercontent.com/1173416/203711936-b3daad91-72d9-48a6-b3b2-d731e9c38d72.png)


