### PR TITLE
fix: address milestone alignment re-rendering

### DIFF
--- a/components/roadmap-grid/RoadmapDetailedView.tsx
+++ b/components/roadmap-grid/RoadmapDetailedView.tsx
@@ -2,7 +2,7 @@ import { Box, Spinner } from '@chakra-ui/react';
 import { useHookstate } from '@hookstate/core';
 import type { Dayjs } from 'dayjs';
 import _ from 'lodash';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { getTicks } from '../../lib/client/getTicks';
 import { ViewMode } from '../../lib/enums';
@@ -23,6 +23,7 @@ import { convertIssueDataStateToDetailedViewGroupOld } from '../../lib/client/co
 import { useRouter } from 'next/router';
 import { ErrorBoundary } from '../errors/ErrorBoundary';
 import { usePrevious } from '../../hooks/usePrevious';
+import getUniqIdForGroupedIssues from '../../lib/client/getUniqIdForGroupedIssues';
 
 export function RoadmapDetailed({
   issueDataState
@@ -35,16 +36,16 @@ export function RoadmapDetailed({
   const router = useRouter();
 
   const issuesGroupedState = useHookstate<DetailedViewGroup[]>([]);
-  const groupIssuesCount = issuesGroupedState.reduce((total, group) => total + (1 + group.items.length),0)
-  const groupIssuesCountPrev = usePrevious(groupIssuesCount);
+  const groupedIssuesId = getUniqIdForGroupedIssues(issuesGroupedState.value)
+  const groupedIssuesIdPrev = usePrevious(groupedIssuesId);
   const query = router.query
 
   const setIssuesGroupedState = issuesGroupedState.set
   useEffect(() => {
-    if (viewMode && groupIssuesCountPrev !== groupIssuesCount) {
+    if (viewMode && groupedIssuesIdPrev !== groupedIssuesId) {
       setIssuesGroupedState(() => convertIssueDataStateToDetailedViewGroupOld(issueDataState, viewMode, query))
     }
-  }, [viewMode, query, setIssuesGroupedState, issueDataState, groupIssuesCountPrev, groupIssuesCount]);
+  }, [viewMode, query, setIssuesGroupedState, issueDataState, groupedIssuesIdPrev, groupedIssuesId]);
 
   /**
    * Magic numbers that just seem to work are:

--- a/hooks/usePrevious.ts
+++ b/hooks/usePrevious.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react';
+
+// Hook
+export function usePrevious<T>(value: T): T {
+  // The ref object is a generic container whose current property is mutable ...
+  // ... and can hold any value, similar to an instance property on a class
+  const ref: any = useRef<T>();
+  // Store current value in ref
+  useEffect(() => {
+    ref.current = value;
+  }, [value]); // Only re-run if value changes
+  // Return previous value (happens before update in useEffect above)
+  return ref.current;
+}

--- a/lib/client/getUniqIdForGroupedIssues.ts
+++ b/lib/client/getUniqIdForGroupedIssues.ts
@@ -6,7 +6,7 @@ interface GetUniqIdForGroupedIssuesArgs extends Omit<DetailedViewGroup, 'items'>
 }
 export default function getUniqIdForGroupedIssues (groupedIssues: GetUniqIdForGroupedIssuesArgs[]): string {
   return groupedIssues.map((group) => {
-    const groupChildrenId = group.items.map((child) => child.node_id).join('-')
+    const groupChildrenId = group.items.map(({ node_id }) => node_id).join('-')
     return `${group.groupName}${groupChildrenId}`
   }).join('--')
 }

--- a/lib/client/getUniqIdForGroupedIssues.ts
+++ b/lib/client/getUniqIdForGroupedIssues.ts
@@ -1,0 +1,12 @@
+import { DetailedViewGroup, IssueData } from '../types';
+
+
+interface GetUniqIdForGroupedIssuesArgs extends Omit<DetailedViewGroup, 'items'> {
+  items: Pick<IssueData, 'node_id'>[]
+}
+export default function getUniqIdForGroupedIssues (groupedIssues: GetUniqIdForGroupedIssuesArgs[]): string {
+  return groupedIssues.map((group) => {
+    const groupChildrenId = group.items.map((child) => child.node_id).join('-')
+    return `${group.groupName}${groupChildrenId}`
+  }).join('--')
+}

--- a/tests/unit/client/getUniqIdForGroupedIssues.test.ts
+++ b/tests/unit/client/getUniqIdForGroupedIssues.test.ts
@@ -1,0 +1,36 @@
+import getUniqIdForGroupedIssues from '../../../lib/client/getUniqIdForGroupedIssues'
+
+describe('getUniqIdForGroupedIssues', function() {
+  it('returns empty string for empty array', () => {
+    expect(getUniqIdForGroupedIssues([])).toEqual('');
+  });
+  it('Returns only groupName for group without children', () => {
+    expect(getUniqIdForGroupedIssues([{ groupName: 'test123', items: [], url: 'nothing' }])).toEqual('test123')
+  });
+  it('Returns both groupNames for two groups without children', () => {
+    expect(getUniqIdForGroupedIssues([
+      { groupName: 'test123', items: [], url: 'nothing' },
+      { groupName: 'abc987', items: [], url: 'nothing2' },
+    ])).toEqual('test123--abc987');
+  });
+  it('Respects sort order', () => {
+    expect(getUniqIdForGroupedIssues([
+      { groupName: 'item1', items: [], url: 'nothing' },
+      { groupName: 'item2', items: [], url: 'nothing2' },
+    ])).toEqual('item1--item2');
+    expect(getUniqIdForGroupedIssues([
+      { groupName: 'item2', items: [], url: 'nothing2' },
+      { groupName: 'item1', items: [], url: 'nothing' },
+    ])).toEqual('item2--item1');
+  });
+  it('Returns children and groupName', () => {
+    expect(getUniqIdForGroupedIssues([
+      { groupName: 'item1', items: [{ node_id: 'childA' }], url: 'nothing' },
+      { groupName: 'item2', items: [], url: 'nothing2' },
+    ])).toEqual('item1childA--item2');
+    expect(getUniqIdForGroupedIssues([
+      { groupName: 'item1', items: [{ node_id: 'child1A' }, { node_id: 'child1B' }], url: 'nothing' },
+      { groupName: 'item2', items: [{ node_id: 'child2A' }], url: 'nothing2' },
+    ])).toEqual('item1child1A-child1B--item2child2A');
+  })
+})


### PR DESCRIPTION
- fix: milestones are accurate when strictMode=false
- feat: use uniq id for grouped issues

- https://github.com/drand/roadmap/issues/1 - [demo link](https://starmaps-git-236-bug-milestone-alignment-is-off-ipfs-ignite.vercel.app/roadmap/github.com/drand/roadmap/issues/1)
- https://github.com/cryptonetlab/roadmap/issues/22 - [demo link](https://starmaps-git-236-bug-milestone-alignment-is-off-ipfs-ignite.vercel.app/roadmap/github.com/cryptonetlab/roadmap/issues/22)